### PR TITLE
Dockerise the CLI

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,14 @@
+.git/
+
+**/*~
+**/.#*
+**/*#
+**/htmlcov
+**/__pycache__
+**/*.pyc
+**/.python-version
+**/.env
+**/.venv
+**/venv
+**/.coverage
+**/*.egg-info/

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,6 +1,12 @@
 ---
 name: CI
 
+env:
+  IMAGE_NAME: metrics
+  PUBLIC_IMAGE_NAME: ghcr.io/ebmdatalab/metrics
+  REGISTRY: ghcr.io
+  SSH_AUTH_SOCK: /tmp/agent.sock
+
 on:
   push:
 
@@ -66,6 +72,55 @@ jobs:
         with:
             name: metrics-image
             path: /tmp/metrics.tar.gz
+
+  deploy:
+    needs:
+    - check
+    - test
+    - docker-test-and-build
+    - lint-dockerfile
+
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+      packages: write
+
+    if: github.ref == 'refs/heads/main'
+
+    concurrency: deploy-production
+
+    steps:
+      - uses: actions/checkout@v4
+      - uses: "opensafely-core/setup-action@v1"
+        with:
+          install-just: true
+
+      - name: Download docker image
+        uses: actions/download-artifact@v3
+        with:
+            name: metrics-image
+            path: /tmp/image
+
+      - name: Import docker image
+        run: gunzip -c /tmp/image/metrics.tar.gz | docker load
+
+      - name: Test image we imported from previous job works
+        run: |
+            SKIP_BUILD=1 just docker-run prod python -m metrics
+
+      - name: Publish image
+        run: |
+            echo ${{ secrets.GITHUB_TOKEN }} | docker login "$REGISTRY" -u ${{ github.actor }} --password-stdin
+            docker tag "$IMAGE_NAME" "$PUBLIC_IMAGE_NAME":latest
+            docker push "$PUBLIC_IMAGE_NAME":latest
+
+      - name: Deploy image
+        run: |
+            ssh-agent -a "$SSH_AUTH_SOCK" > /dev/null
+            ssh-add - <<< "${{ secrets.DOKKU3_DEPLOY_SSH_KEY }}"
+            SHA=$(docker inspect --format='{{index .RepoDigests 0}}' "$PUBLIC_IMAGE_NAME":latest)
+            ssh -o "UserKnownHostsFile=/dev/null" -o "StrictHostKeyChecking=no" dokku@dokku3.ebmdatalab.net git:from-image metrics "$SHA"
 
   required-checks:
     if: always()

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -30,12 +30,51 @@ jobs:
         run: |
           just test
 
+  lint-dockerfile:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+      - uses: hadolint/hadolint-action@54c9adbab1582c2ef04b2016b760714a4bfde3cf  # v3.1.0
+        with:
+          dockerfile: docker/Dockerfile
+
+  docker-test-and-build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+      - uses: "opensafely-core/setup-action@v1"
+        with:
+          install-just: true
+
+      - name: Build docker image for both prod and dev
+        run: |
+            just docker-build prod
+            just docker-build dev
+
+      - name: Run smoke test on prod
+        run: |
+          just docker-run prod python -m metrics
+
+      - name: Save docker image
+        run: |
+          docker save metrics | gzip > /tmp/metrics.tar.gz
+
+      - name: Upload docker image
+        uses: actions/upload-artifact@v3
+        with:
+            name: metrics-image
+            path: /tmp/metrics.tar.gz
+
   required-checks:
     if: always()
 
     needs:
     - check
     - test
+    - docker-test-and-build
+    - lint-dockerfile
 
     runs-on: Ubuntu-latest
 

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -38,6 +38,55 @@ services:
     volumes:
       - timescaledb:/home/postgres/pgdata/data
 
+  metrics-prod:
+    # image name, both locally and public
+    image: metrics
+    build:
+      dockerfile: docker/Dockerfile
+      # the prod stage in the Dockerfile
+      target: metrics-prod
+      # should speed up the build in CI, where we have a cold cache
+      cache_from:  # should speed up the build in CI, where we have a cold cache
+        - ghcr.io/opensafely-core/base-docker
+        - ghcr.io/ebmdatalab/metrics
+      args:
+        # this makes the image work for later cache_from: usage
+        - BUILDKIT_INLINE_CACHE=1
+        # env vars should be supplied by just
+        - BUILD_DATE
+        - GITREF
+    # use dockers builitin PID daemon
+    init: true
+    environment:
+      - GITHUB_TOKEN=dummy
+      - SLACK_SIGNING_SECRET=dummy
+      - SLACK_TECH_SUPPORT_CHANNEL_ID=dummy
+      - SLACK_TOKEN=dummy
+      - TIMESCALEDB_URL=dummy
+
+  # main development service
+  metrics-dev:
+    extends:
+        service: metrics-prod
+    image: metrics-dev
+    container_name: metrics-dev
+    # running as a specific uid/gid allows files written to mounted volumes by
+    # the docker container's default user to match the host user's uid/gid, for
+    # convienience.
+    user: ${DEV_USERID:-1000}:${DEV_GROUPID:-1000}
+    build:
+      # the dev stage in the Dockerfile
+      target: metrics-dev
+      # pass the uid/gid as build arg
+      args:
+        - DEV_USERID=${DEV_USERID:-1000}
+        - DEV_GROUPID=${DEV_GROUPID:-1000}
+    volumes:
+      # mount our current code
+      - .:/app
+    env_file:
+      - .env
+
 volumes:
   postgres:
   grafana:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -30,7 +30,9 @@ services:
   timescaledb:
     image: timescale/timescaledb-ha:pg14-latest
     environment:
-      POSTGRES_PASSWORD: password
+      POSTGRES_DB: metrics
+      POSTGRES_PASSWORD: pass
+      POSTGRES_USER: user
     ports:
       - 5433:5432
     volumes:

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,160 @@
+# syntax=docker/dockerfile:1.2
+#################################################
+#
+# Create base image with python installed.
+#
+# DL3007 ignored because base-docker we specifically always want to build on
+# the latest base image, by design.
+#
+# hadolint ignore=DL3007
+FROM ghcr.io/opensafely-core/base-docker:22.04 as base-python
+
+# we are going to use an apt cache on the host, so disable the default debian
+# docker clean up that deletes that cache on every apt install
+RUN rm -f /etc/apt/apt.conf.d/docker-clean
+
+# ensure fully working base python3.11 installation using deadsnakes ppa
+# see: https://gist.github.com/tiran/2dec9e03c6f901814f6d1e8dad09528e
+# use space efficient utility from base image
+RUN --mount=type=cache,target=/var/cache/apt \
+    echo "deb http://ppa.launchpad.net/deadsnakes/ppa/ubuntu jammy main" > /etc/apt/sources.list.d/deadsnakes-ppa.list &&\
+    /usr/lib/apt/apt-helper download-file 'https://keyserver.ubuntu.com/pks/lookup?op=get&search=0xf23c5a6cf475977595c89f51ba6932366a755776' /etc/apt/trusted.gpg.d/deadsnakes.asc
+
+# install any additional system dependencies
+COPY docker/dependencies.txt /tmp/dependencies.txt
+RUN --mount=type=cache,target=/var/cache/apt \
+    /root/docker-apt-install.sh /tmp/dependencies.txt
+
+
+##################################################
+#
+# Build image
+#
+# Ok, now we have local base image with python and our system dependencies on.
+# We'll use this as the base for our builder image, where we'll build and
+# install any python packages needed.
+#
+# We use a separate, disposable build image to avoid carrying the build
+# dependencies into the production image.
+FROM base-python as builder
+
+# Install any system build dependencies
+COPY docker/build-dependencies.txt /tmp/build-dependencies.txt
+RUN --mount=type=cache,target=/var/cache/apt \
+    /root/docker-apt-install.sh /tmp/build-dependencies.txt
+
+# Install everything in venv for isolation from system python libraries
+RUN python3.11 -m venv /opt/venv
+ENV VIRTUAL_ENV=/opt/venv/ PATH="/opt/venv/bin:$PATH"
+
+# The cache mount means a) /root/.cache is not in the image, and b) it's preserved
+# between docker builds locally, for faster dev rebuild.
+COPY requirements.prod.txt /tmp/requirements.prod.txt
+
+# DL3042: using cache mount instead
+# DL3013: we always want latest pip/setuptools/wheel, at least for now
+# hadolint ignore=DL3042,DL3013
+RUN --mount=type=cache,target=/root/.cache \
+    /opt/venv/bin/python -m pip install -U pip setuptools wheel && \
+    /opt/venv/bin/python -m pip install --no-deps --require-hashes --requirement /tmp/requirements.prod.txt
+
+
+##################################################
+#
+# Base project image
+#
+# Ok, we've built everything we need, build an image with all dependencies but
+# no code.
+#
+# Not including the code at this stage has two benefits:
+#
+# 1) this image only rebuilds when the handfull of files needed to build metrics-base
+#    changes. If we do `COPY . /app` now, this will rebuild when *any* file changes.
+#
+# 2) Ensures we *have* to mount the volume for dev image, as there's no embedded
+#    version of the code. Otherwise, we could end up accidentally using the
+#    version of the code included when the prod image was built.
+FROM base-python as metrics-base
+
+# Create a non-root metrics user to run the app as
+RUN useradd --create-home --user-group metrics
+
+# copy venv over from builder image. These will have root:root ownership, but
+# are readable by all.
+COPY --from=builder /opt/venv /opt/venv
+
+# Ensure we're using the venv by default
+ENV VIRTUAL_ENV=/opt/venv/ PATH="/opt/venv/bin:$PATH"
+
+RUN mkdir /app
+WORKDIR /app
+
+# We set command rather than entrypoint, to make it easier to run different
+# things from the cli
+CMD ["/opt/venv/bin/python", "-m", "metrics"]
+
+# This may not be necessary, but it probably doesn't hurt
+ENV PYTHONPATH=/app
+
+# switch to running as the user
+USER metrics
+
+
+##################################################
+#
+# Production image
+#
+# Copy code in, add proper metadata
+FROM metrics-base as metrics-prod
+
+# Adjust this metadata to fit project. Note that the base-docker image does set
+# some basic metadata.
+LABEL org.opencontainers.image.title="metrics" \
+      org.opencontainers.image.description="Bennett Institute internal metrics tranformation tool" \
+      org.opencontainers.image.source="https://github.com/ebmdatalab/metrics"
+
+# copy application code
+COPY metrics /app/metrics
+
+# finally, tag with build information. These will change regularly, therefore
+# we do them as the last action.
+ARG BUILD_DATE=unknown
+LABEL org.opencontainers.image.created=$BUILD_DATE
+ARG GITREF=unknown
+LABEL org.opencontainers.image.revision=$GITREF
+
+
+
+##################################################
+#
+# Dev image
+#
+# Now we build a dev image from our metrics-dev image. This is basically
+# installing dev dependencies and matching local UID/GID. It is expected that
+# the current code will be mounted in /app when this is run
+#
+FROM metrics-base as metrics-dev
+
+# switch back to root to run the install of dev requirements.txt
+USER root
+
+# install development requirements
+COPY requirements.dev.txt /tmp/requirements.dev.txt
+# using cache mount instead
+# hadolint ignore=DL3042
+RUN --mount=type=cache,target=/root/.cache \
+    python -m pip install --requirement /tmp/requirements.dev.txt
+
+# in dev, ensure metrics uid matches host user id
+ARG DEV_USERID=1000
+ARG DEV_GROUPID=1000
+RUN usermod -u $DEV_USERID metrics
+# Modify metrics only if group id does not already exist. We run dev
+# containers with an explicit group id anyway, so file permissions on the host
+# will be correct, and we do not actually rely on named metrics group access to
+# anything.
+RUN grep -q ":$DEV_GROUPID:" /etc/group || groupmod -g $DEV_GROUPID metrics
+
+
+# switch back to metrics
+USER metrics

--- a/docker/build-dependencies.txt
+++ b/docker/build-dependencies.txt
@@ -1,0 +1,4 @@
+# list ubuntu packges needed to build dependencies, one per line
+build-essential
+libpq-dev
+python3.11-dev

--- a/docker/dependencies.txt
+++ b/docker/dependencies.txt
@@ -1,0 +1,7 @@
+# list ubuntu packages needed in production, one per line
+git
+postgresql-client
+python3.11
+python3.11-distutils
+python3.11-venv
+tzdata

--- a/dotenv-sample
+++ b/dotenv-sample
@@ -1,0 +1,17 @@
+# The DSN for access the timescaledb database
+TIMESCALEDB_URL=postgres://user:pass@localhost:5433/metrics
+
+# API token for pulling data from Github
+GITHUB_TOKEN=
+
+# Slack API access credentials.
+# The slack app used for this will need the following OAuth scopes:
+#  * channels:history
+#  * groups:history
+#  * im:history
+#  * npim:history
+SLACK_SIGNING_SECRET=
+SLACK_TOKEN=
+
+# Slack channel ID for tech-support-channel
+SLACK_TECH_SUPPORT_CHANNEL_ID=C0270Q313H7

--- a/justfile
+++ b/justfile
@@ -127,7 +127,7 @@ fix: devenv
 
 # Run the grafana stack
 grafana:
-    docker-compose up grafana
+    docker compose up grafana
 
 
 metrics *args: devenv
@@ -148,10 +148,10 @@ docker-build env="dev":
     export GITREF=$(git rev-parse --short HEAD)
 
     # build the thing
-    docker-compose build --pull metrics-{{ env }}
+    docker compose build --pull metrics-{{ env }}
 
 
 # run command in dev|prod container
 docker-run env="dev" *args="bash":
     {{ just_executable() }} docker-build {{ env }}
-    docker-compose run --rm metrics-{{ env }} {{ args }}
+    docker compose run --rm metrics-{{ env }} {{ args }}

--- a/justfile
+++ b/justfile
@@ -119,9 +119,9 @@ fix: devenv
     $BIN/ruff --fix .
 
 
-# Run the dev project
-run: devenv
-    docker-compose up
+# Run the grafana stack
+grafana:
+    docker-compose up grafana
 
 
 metrics *args: devenv

--- a/justfile
+++ b/justfile
@@ -131,7 +131,7 @@ grafana:
 
 
 metrics *args: devenv
-    python -m metrics {{ args }}
+    $BIN/python -m metrics {{ args }}
 
 
 docker-build env="dev":

--- a/metrics/cli.py
+++ b/metrics/cli.py
@@ -7,15 +7,15 @@ from .slack.cli import slack
 
 @click.group()
 @click.option("--debug", default=False, is_flag=True)
-@click.option("--database-url", required=True, envvar="DATABASE_URL")
+@click.option("--timescaledb-url", required=True, envvar="TIMESCALEDB_URL")
 @click.pass_context
-def cli(ctx, debug, database_url):
+def cli(ctx, debug, timescaledb_url):
     ctx.ensure_object(dict)
 
     setup_logging(debug)
 
     ctx.obj["DEBUG"] = debug
-    ctx.obj["DATABASE_URL"] = database_url
+    ctx.obj["TIMESCALEDB_URL"] = timescaledb_url
 
 
 cli.add_command(github)

--- a/metrics/timescaledb/writer.py
+++ b/metrics/timescaledb/writer.py
@@ -9,7 +9,7 @@ from . import tables
 
 log = structlog.get_logger()
 
-DATABASE_URL = os.environ["DATABASE_URL"]
+TIMESCALEDB_URL = os.environ["TIMESCALEDB_URL"]
 
 
 def ensure_table(name):
@@ -25,7 +25,7 @@ def ensure_table(name):
 
 
 def run(sql, *args):
-    with psycopg.connect(DATABASE_URL) as conn:
+    with psycopg.connect(TIMESCALEDB_URL) as conn:
         cursor = conn.cursor()
 
         return cursor.execute(sql, *args)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -75,3 +75,7 @@ extend-ignore = [
 
 [tool.ruff.isort]
 lines-after-imports = 2
+
+
+[tool.setuptools.packages.find]
+include = ["metrics*"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,9 +22,6 @@ dependencies = [
 ]
 dynamic = ["version"]
 
-[project.scripts]
-add_job = "metrics.cli:cli"
-
 [project.urls]
 Home = "https://bennett.ox.ac.uk"
 Source = "https://github.com/opensafely-core/metrics/"

--- a/requirements.prod.in
+++ b/requirements.prod.in
@@ -1,4 +1,0 @@
-# Main prod requirements
-
-# To generate requirements file, run:
-# pip-compile --generate-hashes --output-file=requirements.prod.txt requirements.prod.in


### PR DESCRIPTION
This wraps the CLI tool in docker ready for deployment to a dokku.

I took the job-runner configuration (which is already set up for a CLI tool) and adapted it for this repo.  I've removed all the bits that I thought were job-runner specific (in particular things like where does the docker socket live on the host, SSH config, etc).

Since this is the main tool of the repo I've tried out leaving the docker config in the `docker` directory but moving the invocations up to the main justfile, and putting the docker-compose bits into the existing `docker-compose.yaml`.  Can anyone think of any problems or confusion this might cause?

I've done a little tidying along the way, most notably set up a static username and db name for timescaledb, and put that configuration into the `dotenv-sample` which both docker and the justfile are now autoloading.

You should be able to test this with `just docker-run dev python -m metrics` and get the help text that `just metrics` gives you.

I suspect we'll have some bugs to iron out once we start running this in production but I don't know how to start testing it without merging this first.