### PR TITLE
Add the backfill.py module for GitHub to the GitHub subcommand

### DIFF
--- a/metrics/github/cli.py
+++ b/metrics/github/cli.py
@@ -5,6 +5,7 @@ import structlog
 
 from ..timescaledb import TimescaleDBWriter
 from . import api
+from .backfill import backfill
 from .prs import process_prs
 
 
@@ -60,3 +61,6 @@ def pr_throughput(ctx, org, date, days):
     log.info("%s | %s | Processing %s PRs", date, org, len(prs))
     with TimescaleDBWriter("github_pull_requests", "throughput") as writer:
         process_prs(writer, prs, date)
+
+
+github.add_command(backfill)


### PR DESCRIPTION
We want this as part of the CLI to avoid having to special case packaging it.

The only real change here is the removal of the hard-coded orgs list which are now an arg passed via the CLI.

Note: this is still using the github-to-sqlite method for speed and simplicity.