### PR TITLE
grant RO permissions to the grafanareader user when creating tables

### DIFF
--- a/metrics/timescaledb/writer.py
+++ b/metrics/timescaledb/writer.py
@@ -23,6 +23,9 @@ def ensure_table(name):
         [name],
     )
 
+    # ensure the RO grafana user can read the table
+    run(f"GRANT SELECT ON {name} TO grafanareader")
+
 
 def run(sql, *args):
     with psycopg.connect(TIMESCALEDB_URL) as conn:


### PR DESCRIPTION
We use the grafanareader user to limit what access the grafana deployment has to the database.  We need to grant SELECT privilege to that user when creating a table.