### PR TITLE
Iterate GitHub data

### DIFF
--- a/metrics/github/api.py
+++ b/metrics/github/api.py
@@ -153,13 +153,16 @@ def prs_open_on_date(org, date):
     return list(_iter_pull_requests(org, date_range))
 
 
-def prs_opened_in_the_last_N_days(org, start, end):
-    # TODO: is index clear here?  it's the date given to the command, from
-    # which we'll work backwards.
+def prs_closed_on_date(org, date):
+    query = f"closed:{date}"
 
-    date_range = f"created:{start}..{end}"
+    return list(_iter_pull_requests(org, query))
 
-    return list(_iter_pull_requests(org, date_range))
+
+def prs_opened_on_date(org, date):
+    query = f"created:{date}"
+
+    return list(_iter_pull_requests(org, query))
 
 
 if __name__ == "__main__":

--- a/metrics/tools/dates.py
+++ b/metrics/tools/dates.py
@@ -1,4 +1,4 @@
-from datetime import date, datetime, timedelta
+from datetime import datetime, timedelta
 
 
 DELTA = timedelta(days=1)
@@ -6,14 +6,14 @@ DELTA = timedelta(days=1)
 
 def date_from_iso(value):
     if value is None:
-        return date.today()
+        return None
 
     return datetime_from_iso(value).date()
 
 
 def datetime_from_iso(value):
     if value is None:
-        return datetime.now()
+        return None
 
     return datetime.fromisoformat(value)
 


### PR DESCRIPTION
Rebake the data based on feedback from @benbc.

#### PR Throughput
This now tracks a count of PRs opened and a count of PRs closed on a given day.  Ben would like to use the closed counts, bucketed by week for the graph but as discussed in slack I've included the opened in case that's useful to compare.  We may bucket by more/less than a week so the data is done by day and we'll bucket in the graph in Grafana.

#### PR Queue
Ben would like to have this only count PRs which have been open >= 7 days.  I've left the other thresholds in for this round of iteration in case they're useful during review.