### PR TITLE
fix: use correct name for saving grafana docker image

### DIFF
--- a/.github/workflows/grafana.yml
+++ b/.github/workflows/grafana.yml
@@ -41,7 +41,7 @@ jobs:
 
       - name: Save docker image
         run: |
-          docker save grafana | gzip > /tmp/grafana.tar.gz
+          docker save grafana-grafana | gzip > /tmp/grafana.tar.gz
 
       - name: Upload docker image
         uses: actions/upload-artifact@v3


### PR DESCRIPTION
there was no image with name `grafana` so it was silently throwing an error & creating an empty tar file.