### PR TITLE
fix: only run grafana workflow if changes to grafana

### DIFF
--- a/.github/workflows/grafana.yml
+++ b/.github/workflows/grafana.yml
@@ -9,6 +9,8 @@ env:
 
 on:
   push:
+    paths:
+      - 'grafana/*'
 
 jobs:
   lint-dockerfile:


### PR DESCRIPTION
* this workflow returns failure when it attempts to re-deploy the same version of our grafana image