### PR TITLE
Configure the timescaledb image with our grafanareader user by default

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -30,7 +30,8 @@ services:
       - grafana:/var/lib/grafana
 
   timescaledb:
-    image: timescale/timescaledb-ha:pg14-latest
+    build:
+      dockerfile: timescaledb/Dockerfile
     environment:
       POSTGRES_DB: metrics
       POSTGRES_PASSWORD: pass

--- a/timescaledb/Dockerfile
+++ b/timescaledb/Dockerfile
@@ -1,0 +1,3 @@
+FROM timescale/timescaledb-ha:pg14-latest@sha256:19eb9276ee367411728e768217120e55300ac9c3bb5eadcf47aa5ded627f6db1
+
+COPY timescaledb/init.sql /docker-entrypoint-initdb.d/

--- a/timescaledb/init.sql
+++ b/timescaledb/init.sql
@@ -1,0 +1,6 @@
+-- set up the grafanareader role with select permissions by default
+CREATE ROLE grafanareader;
+ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT SELECT ON TABLES TO grafanareader;
+ALTER USER grafanareader WITH PASSWORD 'grafana';
+GRANT CONNECT ON DATABASE metrics TO grafanareader;
+GRANT USAGE ON SCHEMA public TO grafanareader;


### PR DESCRIPTION
When running locally we need a `grafanareader` user set up in the timescaledb with appropriate permissions so we the TimescaleDBWriter class can create tables with the right permissions.

If you've run the compose stack locally you'll need to remove the timescaledb volume to make it reinitialise.  So you can test with:
```
docker compose down
docker volume rm metrics_timescaledb
docker compose build timescaledb
docker compose up timescaledb
```

This should run and stay up if all works.  You can then double check it's working by running one of the ingestion commands, a single day of GitHub data is the fastest one.

My intention is to use this same setup to fix CI for #38.