### PR TITLE
Drop GitHub tables before each run

### DIFF
--- a/metrics/github/cli.py
+++ b/metrics/github/cli.py
@@ -91,6 +91,7 @@ def github(ctx, token):
         "opensafely-core",
     ]
     for org in orgs:
+        log.info("Working with org: %s", org)
         prs = list(api.iter_prs(org))
         log.info("Backfilling with %s PRs for %s", len(prs), org)
 

--- a/metrics/timescaledb/__init__.py
+++ b/metrics/timescaledb/__init__.py
@@ -1,6 +1,8 @@
+from .db import drop_tables
 from .writer import TimescaleDBWriter
 
 
 __all__ = [
     "TimescaleDBWriter",
+    "drop_tables",
 ]

--- a/metrics/timescaledb/db.py
+++ b/metrics/timescaledb/db.py
@@ -1,0 +1,111 @@
+import itertools
+
+import structlog
+from sqlalchemy import text
+
+
+log = structlog.get_logger()
+
+
+def batched(iterable, n):
+    """
+    Backport of 3.12's itertools.batched
+
+    https://docs.python.org/3/library/itertools.html#itertools.batched
+
+    batched('ABCDEFG', 3) --> ABC DEF G
+    """
+    it = iter(iterable)
+    while batch := tuple(itertools.islice(it, n)):
+        yield batch
+
+
+def delete_rows(connection, name, n=10000):
+    """
+    Delete N rows from the given table
+    """
+    sql = text(
+        f"""
+        DELETE FROM {name}
+        WHERE time IN (
+            SELECT time
+            FROM {name}
+            ORDER BY time
+            LIMIT :limit
+        )
+        """
+    )
+    connection.execute(sql, {"limit": n})
+
+
+def drop_child_tables(connection, name, n=100):
+    sql = text(
+        f"""
+        SELECT
+          child.relname AS child
+        FROM
+          pg_inherits
+          JOIN pg_class AS child ON (inhrelid = child.oid)
+          JOIN pg_class AS parent ON (inhparent = parent.oid)
+        WHERE
+          parent.relname = '{name}'
+        """,
+    )
+    tables = connection.scalars(sql)
+
+    for batch in batched(tables, 100):
+        tables = ", ".join(batch)
+        connection.execute(text(f"DROP TABLE IF EXISTS {tables}"))
+
+
+def drop_table(connection, name):
+    connection.execute(text(f"DROP TABLE {name}"), {"table_name": name})
+
+
+def drop_tables(connection, *, prefix):
+    """
+    Drop the tables with the given prefix
+
+    We have limited shared memory in our hosted database, so we can't DROP or
+    TRUNCATE our hypertables.  Instead for each "raw" table we need to:
+     * empty the raw rows (from the named table) in batches
+     * drop the sharded "child" tables in batches
+     * drop the now empty raw table
+    """
+    for table in iter_raw_tables(connection, prefix):
+        log.debug("Removing table: %s", table)
+
+        while has_rows(connection, table):
+            delete_rows(connection, table)
+
+        log.debug("Removed all raw rows", table=table)
+
+        drop_child_tables(connection, table)
+        log.debug("Removed all child tables", table=table)
+
+        drop_table(connection, table)
+        log.debug("Removed raw table", table=table)
+
+
+def has_rows(connection, name):
+    """Count the number of rows in the given table"""
+    sql = text(f"SELECT COUNT(*) FROM {name}")
+    return connection.scalar(sql) > 0
+
+
+def iter_raw_tables(connection, prefix):
+    """Get a list of tables which start with the given prefix"""
+    sql = text(
+        """
+        SELECT
+          tablename
+        FROM
+          pg_catalog.pg_tables
+        WHERE
+          schemaname = 'public'
+          AND
+          tablename LIKE :like
+        """
+    )
+
+    yield from connection.scalars(sql, {"like": f"{prefix}_%"})

--- a/tests/metrics/timescaledb/test_db.py
+++ b/tests/metrics/timescaledb/test_db.py
@@ -1,0 +1,26 @@
+from datetime import date, timedelta
+
+from metrics.timescaledb.db import drop_tables
+from metrics.timescaledb.tables import GitHubPullRequests
+from metrics.timescaledb.writer import TimescaleDBWriter
+
+
+def test_drop_tables(engine, has_table):
+    # put enough rows in the db to make sure we exercise the batch removal of
+    # rows.  TimescaleDBWriter will ensure the table exists for us.
+    with TimescaleDBWriter(GitHubPullRequests, engine) as writer:
+        start = date(2020, 4, 1)
+        for i in range(11_000):
+            d = start + timedelta(days=i)
+            writer.write(
+                d,
+                i,
+                name="test",
+                author="test",
+                repo="test",
+            )
+
+    with engine.begin() as connection:
+        drop_tables(connection, prefix="github_")
+
+    assert not has_table(GitHubPullRequests.name)


### PR DESCRIPTION
Now that we're backfilling all data on each run we can simplify some of that by dropping the table each time we run the backfill.  We still maintain the upsert functionality so this is not entirely necessary but it also helps in local development.

The backfill time is down to <2m locally and the expectation is that we'll run backfills in the middle of the night so I'm not expecting this to cause problems for users in production.

While we only have one GitHub table currently this looks for all `github_*` tables on the basis that we're not ingesting all the data all at once so future tables (eg issues) won't have to worry about doing this too.