### PR TITLE
Drop archived repo PRs

### DIFF
--- a/metrics/github/cli.py
+++ b/metrics/github/cli.py
@@ -68,6 +68,9 @@ def open_prs(prs, org, days_threshold):
 
 
 def pr_throughput(prs, org):
+    """
+    PRs opened and closed each day from the earliest day to today
+    """
     start = min([pr["created"] for pr in prs])
     days = list(iter_days(start, date.today()))
 

--- a/metrics/github/prs.py
+++ b/metrics/github/prs.py
@@ -1,3 +1,31 @@
+from datetime import datetime
+
+
+def drop_archived_prs(prs, date):
+    """
+    Drop PRs where their repo's archival date happened before the given date
+
+    We expose a repo's archived date in both date and datetime format, so this
+    function will pick the relevant one based on the type of the given date.
+    """
+
+    suffix = "_at" if isinstance(date, datetime) else ""
+    key = f"repo_archived{suffix}"
+
+    def keep(pr, date):
+        if not pr[key]:
+            # the repo hasn't been archived yet
+            return True
+
+        if date < pr[key]:
+            # the repo has not been archived by date
+            return True
+
+        return False
+
+    return [pr for pr in prs if keep(pr, date)]
+
+
 def process_prs(writer, prs, date, name=""):
     """
     Given a list of PRs, break them down in series for writing

--- a/tests/metrics/github/test_prs.py
+++ b/tests/metrics/github/test_prs.py
@@ -1,8 +1,31 @@
-from datetime import date
+from datetime import date, datetime
 
 import pytest
 
-from metrics.github.prs import process_prs
+from metrics.github.prs import drop_archived_prs, process_prs
+
+
+def test_drop_archived_prs():
+    pr1 = {
+        "repo_archived": date(2023, 11, 6),
+        "repo_archived_at": datetime(2023, 11, 6),
+    }
+    pr2 = {
+        "repo_archived": date(2023, 11, 7),
+        "repo_archived_at": datetime(2023, 11, 7),
+    }
+    pr3 = {
+        "repo_archived": date(2023, 11, 8),
+        "repo_archived_at": datetime(2023, 11, 8),
+    }
+    pr4 = {
+        "repo_archived": None,
+        "repo_archived_at": None,
+    }
+    prs = [pr1, pr2, pr3, pr4]
+
+    assert drop_archived_prs(prs, date=date(2023, 11, 7)) == [pr3, pr4]
+    assert drop_archived_prs(prs, date=datetime(2023, 11, 7)) == [pr3, pr4]
 
 
 def test_process_prs_success():


### PR DESCRIPTION
When counting PRs, stop considering them after their repo has been archived.