### PR TITLE
Security vulnerabilities

### DIFF
--- a/metrics/app.json
+++ b/metrics/app.json
@@ -5,6 +5,10 @@
       "schedule": "@daily"
     },
     {
+      "command": "python -m metrics.github.security",
+      "schedule": "@daily"
+    },
+    {
       "command": "python -m metrics slack tech-support",
       "schedule": "@daily"
     }

--- a/metrics/github/cli.py
+++ b/metrics/github/cli.py
@@ -5,10 +5,10 @@ import structlog
 from sqlalchemy import create_engine
 
 from ..timescaledb import TimescaleDBWriter, drop_tables
-from ..timescaledb.tables import GitHubPullRequests, GitHubVulnerabilities
+from ..timescaledb.tables import GitHubPullRequests
 from ..timescaledb.writer import TIMESCALEDB_URL
 from ..tools.dates import iter_days, previous_weekday
-from . import api, security
+from . import api
 from .prs import drop_archived_prs, process_prs
 
 
@@ -89,14 +89,6 @@ def pr_throughput(prs, org):
             process_prs(writer, merged_prs, day, name="prs_merged")
 
 
-def vulnerabilities(org):
-    vulns = security.parse_vulnerabilities(security.get_vulnerabilities(org), org)
-    with TimescaleDBWriter(GitHubVulnerabilities) as writer:
-        for v in vulns:
-            date = v.pop("date")
-            writer.write(date, value=0, **v)
-
-
 @click.command()
 @click.option("--token", required=True, envvar="GITHUB_TOKEN")
 @click.pass_context
@@ -123,4 +115,3 @@ def github(ctx, token):
 
         open_prs(prs, org, days_threshold=7)
         pr_throughput(prs, org)
-        vulnerabilities(org)

--- a/metrics/github/security.py
+++ b/metrics/github/security.py
@@ -36,6 +36,7 @@ def get_vulnerabilities(org):
         repositories(first: 100) {
           nodes {
             name
+            archivedAt
             vulnerabilityAlerts(first: 100) {
               nodes {
                 number
@@ -90,7 +91,8 @@ def parse_vulnerabilities(vulnerabilities, org):
     for repo in vulnerabilities:
         repo_name = repo["name"]
         alerts = repo["vulnerabilityAlerts"]["nodes"]
-        if not alerts:
+
+        if repo["archivedAt"] or not alerts:
             continue
 
         earliest_date = datetime.fromisoformat(alerts[0]["createdAt"]).date()
@@ -108,8 +110,8 @@ def parse_vulnerabilities(vulnerabilities, org):
 
 def print_vulnerabilities(vulns):  # pragma: no cover
     print(f"There are {len(vulns)} alerts")
-    print(parse_vulnerabilities(vulns))
+    print(parse_vulnerabilities(vulns, "opensafely-core"))
 
 
 if __name__ == "__main__":  # pragma: no cover
-    print_vulnerabilities(get_vulnerabilities())
+    print_vulnerabilities(get_vulnerabilities("opensafely-core"))

--- a/metrics/github/security.py
+++ b/metrics/github/security.py
@@ -1,0 +1,115 @@
+import os
+from datetime import datetime, timedelta
+
+import requests
+import structlog
+
+
+log = structlog.get_logger()
+
+GITHUB_TOKEN = os.environ["GITHUB_TOKEN"]
+
+session = requests.Session()
+session.headers = {
+    "Authorization": f"bearer {GITHUB_TOKEN}",
+    "User-Agent": "Bennett Metrics Testing",
+}
+
+
+def make_request(query, variables):
+    response = session.post(
+        "https://api.github.com/graphql", json={"query": query, "variables": variables}
+    )
+
+    if not response.ok:
+        print(response.headers)
+        print(response.content)
+
+    response.raise_for_status()
+    return response.json()
+
+
+def get_vulnerabilities(org):
+    query = """
+    query vulnerabilities($org: String!) {
+      organization(login: $org) {
+        repositories(first: 100) {
+          nodes {
+            name
+            vulnerabilityAlerts(first: 100) {
+              nodes {
+                number
+                createdAt
+                fixedAt
+                dismissedAt
+              }
+              pageInfo {
+                hasNextPage endCursor
+              }
+            }
+          }
+        }
+      }
+    }
+    """
+    variables = {"org": org}
+    response = make_request(query, variables)
+    return response["data"]["organization"]["repositories"]["nodes"]
+
+
+def date_before(date_string, target_date):
+    if not date_string:
+        return False
+
+    return datetime.fromisoformat(date_string).date() <= target_date
+
+
+def parse_vulnerabilities_for_date(vulns, repo, target_date, org):
+    closed_vulns = 0
+    open_vulns = 0
+    for row in vulns:
+        if date_before(row["fixedAt"], target_date) or date_before(
+            row["dismissedAt"], target_date
+        ):
+            closed_vulns += 1
+        elif date_before(row["createdAt"], target_date):
+            open_vulns += 1
+
+    return {
+        "date": target_date,
+        "closed": closed_vulns,
+        "open": open_vulns,
+        "organisation": org,
+        "repo": repo,
+    }
+
+
+def parse_vulnerabilities(vulnerabilities, org):
+    results = []
+
+    for repo in vulnerabilities:
+        repo_name = repo["name"]
+        alerts = repo["vulnerabilityAlerts"]["nodes"]
+        if not alerts:
+            continue
+
+        earliest_date = datetime.fromisoformat(alerts[0]["createdAt"]).date()
+        latest_date = datetime.fromisoformat(alerts[-1]["createdAt"]).date()
+        one_day = timedelta(days=1)
+
+        while earliest_date <= latest_date:
+            results.append(
+                parse_vulnerabilities_for_date(alerts, repo_name, earliest_date, org)
+            )
+            earliest_date += one_day
+
+    return results
+
+
+def print_vulnerabilities(vulns):  # pragma: no cover
+    print(f"There are {len(vulns)} alerts")
+    print(parse_vulnerabilities(vulns))
+
+
+if __name__ == "__main__":  # pragma: no cover
+    print_vulnerabilities(get_vulnerabilities())

--- a/metrics/timescaledb/tables.py
+++ b/metrics/timescaledb/tables.py
@@ -14,6 +14,19 @@ GitHubPullRequests = Table(
     Column("repo", Text, primary_key=True),
 )
 
+
+GitHubVulnerabilities = Table(
+    "github_vulnerabilities",
+    metadata,
+    Column("time", TIMESTAMP(timezone=True), primary_key=True),
+    Column("value", Integer),
+    Column("open", Integer),
+    Column("closed", Integer),
+    Column("organisation", Text),
+    Column("repo", Text, primary_key=True),
+)
+
+
 SlackTechSupport = Table(
     "slack_tech_support",
     metadata,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,7 @@ source = [
 ]
 
 [tool.coverage.report]
-fail_under = 70
+fail_under = 76
 skip_covered = true
 show_missing = true
 

--- a/tests/metrics/github/test_security.py
+++ b/tests/metrics/github/test_security.py
@@ -7,6 +7,7 @@ def fake_vulnerabilities(org):
     github_response = [
         {
             "name": "opencodelists",
+            "archivedAt": None,
             "vulnerabilityAlerts": {
                 "nodes": [
                     {

--- a/tests/metrics/github/test_security.py
+++ b/tests/metrics/github/test_security.py
@@ -1,0 +1,98 @@
+from datetime import date
+
+from metrics.github import security
+
+
+def fake_vulnerabilities(org):
+    github_response = [
+        {
+            "name": "opencodelists",
+            "vulnerabilityAlerts": {
+                "nodes": [
+                    {
+                        "number": 8,
+                        "createdAt": "2022-02-10T01:36:54Z",
+                        "fixedAt": None,
+                        "dismissedAt": None,
+                    },
+                    {
+                        "number": 23,
+                        "createdAt": "2022-10-18T17:20:30Z",
+                        "fixedAt": "2022-10-24T14:27:29Z",
+                        "dismissedAt": None,
+                    },
+                    {
+                        "number": 24,
+                        "createdAt": "2022-10-18T21:08:22Z",
+                        "fixedAt": "2022-11-09T13:01:04Z",
+                        "dismissedAt": None,
+                    },
+                    {
+                        "number": 25,
+                        "createdAt": "2022-11-01T17:52:53Z",
+                        "fixedAt": "2022-11-07T15:14:37Z",
+                        "dismissedAt": None,
+                    },
+                    {
+                        "number": 55,
+                        "createdAt": "2023-08-30T04:44:56Z",
+                        "fixedAt": None,
+                        "dismissedAt": "2023-09-04T15:07:44Z",
+                    },
+                    {
+                        "number": 57,
+                        "createdAt": "2023-10-03T02:46:00Z",
+                        "fixedAt": None,
+                        "dismissedAt": None,
+                    },
+                    {
+                        "number": 64,
+                        "createdAt": "2023-10-26T15:02:17Z",
+                        "fixedAt": None,
+                        "dismissedAt": None,
+                    },
+                ]
+            },
+        }
+    ]
+    return github_response
+
+
+def test_security_number_of_alerts_today():
+    today = date(2023, 11, 28)
+
+    alerts = fake_vulnerabilities("test-org")[0]["vulnerabilityAlerts"]["nodes"]
+    result = security.parse_vulnerabilities_for_date(
+        alerts, "opencodelists", today, "test-org"
+    )
+
+    assert str(result["date"]) == "2023-11-28"
+    assert result["closed"] == 4
+    assert result["open"] == 3
+
+
+def test_security_number_of_alerts_last_year():
+    target_date = date(2022, 11, 1)
+
+    alerts = fake_vulnerabilities("test-org")[0]["vulnerabilityAlerts"]["nodes"]
+    result = security.parse_vulnerabilities_for_date(
+        alerts, "opencodelists", target_date, "test-org"
+    )
+
+    assert str(result["date"]) == "2022-11-01"
+    assert result["closed"] == 1
+    assert result["open"] == 3
+
+
+def test_security_parse_vulnerabilities_earliest_and_latest_date():
+    result = security.parse_vulnerabilities(
+        fake_vulnerabilities("test-org"), "test-org"
+    )
+
+    assert len(result) == 624
+    assert str(result[0]["date"]) == "2022-02-10"
+    assert result[0]["closed"] == 0
+    assert result[0]["open"] == 1
+    assert str(result[-1]["date"]) == "2023-10-26"
+    assert result[-1]["closed"] == 4
+    assert result[-1]["open"] == 3


### PR DESCRIPTION
This counts the number of vulnerability alerts that were either open or closed
for any given date and any repo. Alerts are never deleted, they are either
fixed or dismissed.

These counts are then written to a db table. For some reason, the db table
needs to have a column called "value". I'm not sure why and it's not being used
at the moment.

There is no paging on requests to the graphql api at the moment, so some repos
in the ebmdatalab org will be getting missed. In future, we will miss some
vulnerabilities too if we don't page the results.