### PR TITLE
Revert "fix: also run grafana workflow when we change the workflow"

### DIFF
--- a/.github/workflows/grafana.yml
+++ b/.github/workflows/grafana.yml
@@ -11,7 +11,6 @@ on:
   push:
     paths:
       - 'grafana/*'
-      - '.github/workflows/grafana.yml'
 
 jobs:
   lint-dockerfile:


### PR DESCRIPTION
Reverts ebmdatalab/metrics#35

* the deployment task has not run after merging this PR - it should have run for https://github.com/ebmdatalab/metrics/pull/49/files . I'd like to revert this to verify if it runs again
* might need a follow-up PR to kick CI