### PR TITLE
Raise error for debugging purposes

### DIFF
--- a/metrics/github/security.py
+++ b/metrics/github/security.py
@@ -1,3 +1,4 @@
+import json
 import os
 
 import requests
@@ -60,6 +61,9 @@ def get_vulnerabilities(org):
     """
     variables = {"org": org}
     response = make_request(query, variables)
+    if "data" not in response:
+        raise RuntimeError(json.dumps(response, indent=2))
+
     return response["data"]["organization"]["repositories"]["nodes"]
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,7 @@ source = [
 ]
 
 [tool.coverage.report]
-fail_under = 76
+fail_under = 75
 skip_covered = true
 show_missing = true
 


### PR DESCRIPTION
This didn't work on the server. It's probably a difference in the token that's used, but hopefully raising an error will provide more information.