### PR TITLE
Fine grained GitHub tokens

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -52,7 +52,8 @@ jobs:
 
       - name: Run tests
         env:
-          GITHUB_TOKEN:
+          GITHUB_EBMDATALAB_TOKEN:
+          GITHUB_OS_CORE_TOKEN:
           SLACK_SIGNING_SECRET:
           SLACK_TECH_SUPPORT_CHANNEL_ID:
           SLACK_TOKEN:

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -16,6 +16,8 @@ dokku config:set metrics SLACK_TOKEN='xxx'
 dokku config:set metrics TIMESCALEDB_URL='xxx'
 ```
 
+The `GITHUB_EBMDATALAB_TOKEN` and `GITHUB_OS_CORE_TOKEN` are fine-grained GitHub personal access tokens that are used for authenticating with the GitHub GraphQL API. Each token is assigned to a single organisation and should have read access to *all repositories* owned by that organisation with the following repository permissions: Code scanning alerts, Dependabot alerts, Metadata, Pull requests and Repository security advisories.
+
 ## Disable checks
 Dokku performs health checks on apps during deploy by sending requests to port 80.
 This tool isn't a web app so it can't accept requests on a port.

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -8,6 +8,8 @@ dokku$ dokku git:set metrics deploy-branch main
 ## Configure app
 ```bash
 dokku config:set metrics GITHUB_TOKEN'xxx'
+dokku config:set metrics GITHUB_EBMDATALAB_TOKEN='xxx'
+dokku config:set metrics GITHUB_OS_CORE_TOKEN='xxx'
 dokku config:set metrics SLACK_SIGNING_SECRET='xxx'
 dokku config:set metrics SLACK_TECH_SUPPORT_CHANNEL_ID='xxx'
 dokku config:set metrics SLACK_TOKEN='xxx'

--- a/dotenv-sample
+++ b/dotenv-sample
@@ -3,6 +3,8 @@ TIMESCALEDB_URL=postgresql://user:pass@localhost:5433/metrics
 
 # API token for pulling data from Github
 GITHUB_TOKEN=
+GITHUB_EBMDATALAB_TOKEN=
+GITHUB_OS_CORE_TOKEN=
 
 # Slack API access credentials.
 # The slack app used for this will need the following OAuth scopes:

--- a/metrics/github/api.py
+++ b/metrics/github/api.py
@@ -1,7 +1,6 @@
 import json
 import os
 import textwrap
-from datetime import date
 
 import requests
 import structlog
@@ -156,13 +155,12 @@ def iter_repo_prs(client, repo):
         }
 
 
-def iter_prs(org):
-    client = GitHubClient(org, GITHUB_TOKEN)
+def iter_prs(client):
     for repo in iter_repos(client):
         yield from iter_repo_prs(client, repo)
 
 
 if __name__ == "__main__":
-    orgs = ["ebmdatalab", "opensafely-core"]
-    for pr in list(iter_prs(orgs[1], date(2023, 10, 24))):
+    client = GitHubClient("opensafely-core", GITHUB_TOKEN)
+    for pr in iter_prs(client):
         print(pr)

--- a/metrics/github/api.py
+++ b/metrics/github/api.py
@@ -1,5 +1,4 @@
 import json
-import os
 import textwrap
 
 import requests
@@ -156,10 +155,3 @@ def iter_repo_prs(client, repo):
 def iter_prs(client):
     for repo in iter_repos(client):
         yield from iter_repo_prs(client, repo)
-
-
-if __name__ == "__main__":
-    GITHUB_TOKEN = os.environ["GITHUB_TOKEN"]
-    client = GitHubClient("opensafely-core", GITHUB_TOKEN)
-    for pr in iter_prs(client):
-        print(pr)

--- a/metrics/github/api.py
+++ b/metrics/github/api.py
@@ -10,8 +10,6 @@ from ..tools.dates import datetime_from_iso
 
 log = structlog.get_logger()
 
-GITHUB_TOKEN = os.environ["GITHUB_TOKEN"]
-
 
 session = requests.Session()
 
@@ -161,6 +159,7 @@ def iter_prs(client):
 
 
 if __name__ == "__main__":
+    GITHUB_TOKEN = os.environ["GITHUB_TOKEN"]
     client = GitHubClient("opensafely-core", GITHUB_TOKEN)
     for pr in iter_prs(client):
         print(pr)

--- a/metrics/github/cli.py
+++ b/metrics/github/cli.py
@@ -92,7 +92,7 @@ def github(ctx):
 
     timescaledb.reset_table(timescaledb.GitHubPullRequests)
 
-    GITHUB_TOKEN = os.environ["GITHUB_TOKEN"]
+    GITHUB_TOKEN = os.environ.get("GITHUB_TOKEN")
     os_core_token = os.environ.get("GITHUB_OS_CORE_TOKEN", GITHUB_TOKEN)
     ebmdatalab_token = os.environ.get("GITHUB_EBMDATALAB_TOKEN", GITHUB_TOKEN)
     orgs = {

--- a/metrics/github/cli.py
+++ b/metrics/github/cli.py
@@ -93,10 +93,13 @@ def github(ctx):
     timescaledb.reset_table(timescaledb.GitHubPullRequests)
 
     GITHUB_TOKEN = os.environ["GITHUB_TOKEN"]
+    os_core_token = os.environ.get("GITHUB_OS_CORE_TOKEN", GITHUB_TOKEN)
+    ebmdatalab_token = os.environ.get("GITHUB_EBMDATALAB_TOKEN", GITHUB_TOKEN)
     orgs = {
-        "ebmdatalab": GITHUB_TOKEN,
-        "opensafely-core": GITHUB_TOKEN,
+        "ebmdatalab": os_core_token,
+        "opensafely-core": ebmdatalab_token,
     }
+
     for org, token in orgs.items():
         log.info("Working with org: %s", org)
         client = api.GitHubClient(org, token)

--- a/metrics/github/cli.py
+++ b/metrics/github/cli.py
@@ -85,11 +85,9 @@ def pr_throughput(prs, org):
 
 
 @click.command()
-@click.option("--token", required=True, envvar="GITHUB_TOKEN")
 @click.pass_context
-def github(ctx, token):
+def github(ctx):
     ctx.ensure_object(dict)
-    ctx.obj["TOKEN"] = token
 
     timescaledb.reset_table(timescaledb.GitHubPullRequests)
 

--- a/metrics/github/cli.py
+++ b/metrics/github/cli.py
@@ -100,11 +100,9 @@ def github(ctx):
         prs = list(api.iter_prs(org))
         log.info("Backfilling with %s PRs for %s", len(prs), org)
 
-        rows = list(
-            itertools.chain(
-                old_prs(prs, org, days_threshold=7),
-                pr_throughput(prs, org),
-            )
+        rows = itertools.chain(
+            old_prs(prs, org, days_threshold=7),
+            pr_throughput(prs, org),
         )
 
         timescaledb.write(timescaledb.GitHubPullRequests, rows)

--- a/metrics/github/cli.py
+++ b/metrics/github/cli.py
@@ -1,4 +1,5 @@
 import itertools
+import os
 from datetime import UTC, date, datetime, time, timedelta
 
 import click
@@ -91,13 +92,14 @@ def github(ctx):
 
     timescaledb.reset_table(timescaledb.GitHubPullRequests)
 
+    GITHUB_TOKEN = os.environ["GITHUB_TOKEN"]
     orgs = [
         "ebmdatalab",
         "opensafely-core",
     ]
     for org in orgs:
         log.info("Working with org: %s", org)
-        client = api.GitHubClient(org, api.GITHUB_TOKEN)
+        client = api.GitHubClient(org, GITHUB_TOKEN)
         prs = list(api.iter_prs(client))
         log.info("Backfilling with %s PRs for %s", len(prs), org)
 

--- a/metrics/github/cli.py
+++ b/metrics/github/cli.py
@@ -93,13 +93,13 @@ def github(ctx):
     timescaledb.reset_table(timescaledb.GitHubPullRequests)
 
     GITHUB_TOKEN = os.environ["GITHUB_TOKEN"]
-    orgs = [
-        "ebmdatalab",
-        "opensafely-core",
-    ]
-    for org in orgs:
+    orgs = {
+        "ebmdatalab": GITHUB_TOKEN,
+        "opensafely-core": GITHUB_TOKEN,
+    }
+    for org, token in orgs.items():
         log.info("Working with org: %s", org)
-        client = api.GitHubClient(org, GITHUB_TOKEN)
+        client = api.GitHubClient(org, token)
         prs = list(api.iter_prs(client))
         log.info("Backfilling with %s PRs for %s", len(prs), org)
 

--- a/metrics/github/cli.py
+++ b/metrics/github/cli.py
@@ -97,7 +97,8 @@ def github(ctx):
     ]
     for org in orgs:
         log.info("Working with org: %s", org)
-        prs = list(api.iter_prs(org))
+        client = api.GitHubClient(org, api.GITHUB_TOKEN)
+        prs = list(api.iter_prs(client))
         log.info("Backfilling with %s PRs for %s", len(prs), org)
 
         rows = itertools.chain(

--- a/metrics/github/security.py
+++ b/metrics/github/security.py
@@ -104,8 +104,11 @@ if __name__ == "__main__":  # pragma: no cover
     timescaledb.reset_table(timescaledb.GitHubVulnerabilities)
 
     GITHUB_TOKEN = os.environ["GITHUB_TOKEN"]
-    client = api.GitHubClient("ebmdatalab", GITHUB_TOKEN)
+    os_core_token = os.environ.get("GITHUB_OS_CORE_TOKEN", GITHUB_TOKEN)
+    ebmdatalab_token = os.environ.get("GITHUB_EBMDATALAB_TOKEN", GITHUB_TOKEN)
+
+    client = api.GitHubClient("ebmdatalab", ebmdatalab_token)
     vulnerabilities(client)
 
-    client = api.GitHubClient("opensafely-core", GITHUB_TOKEN)
+    client = api.GitHubClient("opensafely-core", os_core_token)
     vulnerabilities(client)

--- a/metrics/github/security.py
+++ b/metrics/github/security.py
@@ -1,4 +1,5 @@
 import json
+import os
 
 import structlog
 
@@ -102,8 +103,9 @@ def vulnerabilities(client):
 if __name__ == "__main__":  # pragma: no cover
     timescaledb.reset_table(timescaledb.GitHubVulnerabilities)
 
-    client = api.GitHubClient("ebmdatalab", api.GITHUB_TOKEN)
+    GITHUB_TOKEN = os.environ["GITHUB_TOKEN"]
+    client = api.GitHubClient("ebmdatalab", GITHUB_TOKEN)
     vulnerabilities(client)
 
-    client = api.GitHubClient("opensafely-core", api.GITHUB_TOKEN)
+    client = api.GitHubClient("opensafely-core", GITHUB_TOKEN)
     vulnerabilities(client)

--- a/metrics/github/security.py
+++ b/metrics/github/security.py
@@ -108,7 +108,9 @@ if __name__ == "__main__":  # pragma: no cover
     ebmdatalab_token = os.environ.get("GITHUB_EBMDATALAB_TOKEN", GITHUB_TOKEN)
 
     client = api.GitHubClient("ebmdatalab", ebmdatalab_token)
+    log.info("Fetching vulnerabilities for %s", client.org)
     vulnerabilities(client)
 
     client = api.GitHubClient("opensafely-core", os_core_token)
+    log.info("Fetching vulnerabilities for %s", client.org)
     vulnerabilities(client)

--- a/metrics/github/security.py
+++ b/metrics/github/security.py
@@ -103,7 +103,7 @@ def vulnerabilities(client):
 if __name__ == "__main__":  # pragma: no cover
     timescaledb.reset_table(timescaledb.GitHubVulnerabilities)
 
-    GITHUB_TOKEN = os.environ["GITHUB_TOKEN"]
+    GITHUB_TOKEN = os.environ.get("GITHUB_TOKEN")
     os_core_token = os.environ.get("GITHUB_OS_CORE_TOKEN", GITHUB_TOKEN)
     ebmdatalab_token = os.environ.get("GITHUB_EBMDATALAB_TOKEN", GITHUB_TOKEN)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,7 @@ source = [
 ]
 
 [tool.coverage.report]
-fail_under = 80
+fail_under = 84
 skip_covered = true
 show_missing = true
 

--- a/tests/metrics/github/test_cli.py
+++ b/tests/metrics/github/test_cli.py
@@ -29,8 +29,7 @@ def test_github():
         Usage: cli github [OPTIONS]
 
         Options:
-          --token TEXT  [required]
-          --help        Show this message and exit.
+          --help  Show this message and exit.
         """
     ).lstrip()  # lstrip so dedent works and we retain the leading newline
     assert result.output == expected, result.output


### PR DESCRIPTION
This change introduces support for a GitHub token per organisation. This is required to move to fine-grained tokens, which are more secure. The old style GitHub tokens require the `repo` permission (which also gives write access) to a) get information about security vulnerabilities b) get any information about private repos.

~:notebook: Before merging, the GitHub workflow should be updated to add the two GitHub tokens.~

This change is otherwise backwards compatible, so the new tokens can be added to dokku after merge.