### PR TITLE
Add three patterns to `.gitignore`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,8 @@
+*.egg-info/
 .coverage
+.env
 .pytest-cache/
 .venv/
+__pycache__/
 github.db
 htmlcov


### PR DESCRIPTION
Directories/files matching these patterns popped up when I cloned the repo and started the local Docker stack. It's likely that everyone else has them in their global `.gitignore`. However, it's useful to have them locally.