### PR TITLE
Remove unused github token

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -7,7 +7,6 @@ dokku$ dokku git:set metrics deploy-branch main
 
 ## Configure app
 ```bash
-dokku config:set metrics GITHUB_TOKEN'xxx'
 dokku config:set metrics GITHUB_EBMDATALAB_TOKEN='xxx'
 dokku config:set metrics GITHUB_OS_CORE_TOKEN='xxx'
 dokku config:set metrics SLACK_SIGNING_SECRET='xxx'

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -61,7 +61,6 @@ services:
     # use dockers builitin PID daemon
     init: true
     environment:
-      - GITHUB_TOKEN=dummy
       - SLACK_SIGNING_SECRET=dummy
       - SLACK_TECH_SUPPORT_CHANNEL_ID=dummy
       - SLACK_TOKEN=dummy
@@ -88,7 +87,6 @@ services:
       # mount our current code
       - .:/app
     environment:
-      - GITHUB_TOKEN=${GITHUB_TOKEN:-}
       - SLACK_SIGNING_SECRET=${SLACK_SIGNING_SECRET:-}
       - SLACK_TECH_SUPPORT_CHANNEL_ID=${SLACK_TECH_SUPPORT_CHANNEL_ID:-}
       - SLACK_TOKEN=${SLACK_TOKEN:-}

--- a/dotenv-sample
+++ b/dotenv-sample
@@ -1,8 +1,7 @@
 # The DSN for access the timescaledb database
 TIMESCALEDB_URL=postgresql://user:pass@localhost:5433/metrics
 
-# API token for pulling data from Github
-GITHUB_TOKEN=
+# API tokens for pulling data from Github
 GITHUB_EBMDATALAB_TOKEN=
 GITHUB_OS_CORE_TOKEN=
 

--- a/metrics/github/cli.py
+++ b/metrics/github/cli.py
@@ -92,12 +92,9 @@ def github(ctx):
 
     timescaledb.reset_table(timescaledb.GitHubPullRequests)
 
-    GITHUB_TOKEN = os.environ.get("GITHUB_TOKEN")
-    os_core_token = os.environ.get("GITHUB_OS_CORE_TOKEN", GITHUB_TOKEN)
-    ebmdatalab_token = os.environ.get("GITHUB_EBMDATALAB_TOKEN", GITHUB_TOKEN)
     orgs = {
-        "ebmdatalab": os_core_token,
-        "opensafely-core": ebmdatalab_token,
+        "ebmdatalab": os.environ["GITHUB_EBMDATALAB_TOKEN"],
+        "opensafely-core": os.environ["GITHUB_OS_CORE_TOKEN"],
     }
 
     for org, token in orgs.items():

--- a/metrics/github/security.py
+++ b/metrics/github/security.py
@@ -128,9 +128,8 @@ def vulnerabilities(client, to_date):
 
 
 if __name__ == "__main__":  # pragma: no cover
-    GITHUB_TOKEN = os.environ.get("GITHUB_TOKEN")
-    os_core_token = os.environ.get("GITHUB_OS_CORE_TOKEN", GITHUB_TOKEN)
-    ebmdatalab_token = os.environ.get("GITHUB_EBMDATALAB_TOKEN", GITHUB_TOKEN)
+    os_core_token = os.environ["GITHUB_OS_CORE_TOKEN"]
+    ebmdatalab_token = os.environ["GITHUB_EBMDATALAB_TOKEN"]
     yesterday = date.today() - timedelta(days=1)
 
     client = api.GitHubClient("ebmdatalab", ebmdatalab_token)


### PR DESCRIPTION
I've updated the tokens used on dokku for communicating with the graphql API and removed the `GITHUB_TOKEN` from dokku altogether. This change removes all references to that token from the code.

