### PR TITLE
Exclude non-Tech-owned repos

### DIFF
--- a/tests/metrics/github/test_cli.py
+++ b/tests/metrics/github/test_cli.py
@@ -4,7 +4,7 @@ from datetime import UTC, datetime, timedelta
 from click.testing import CliRunner
 
 from metrics.cli import cli
-from metrics.github.cli import old_prs, pr_throughput
+from metrics.github.cli import old_prs, pr_throughput, tech_owned_repo
 
 
 def ts(name, author, time, value):
@@ -181,3 +181,14 @@ def test_pr_throughput():
     )
 
     assert output == expected
+
+
+def test_filtering_of_tech_owned_repos():
+    assert tech_owned_repo({"org": "ebmdatalab", "repo": "metrics"})
+    assert not tech_owned_repo(
+        {"org": "ebmdatalab", "repo": "clinicaltrials-act-tracker"}
+    )
+
+
+def test_dont_filter_out_repos_from_unknown_orgs():
+    assert tech_owned_repo({"org": "other", "repo": "any"})


### PR DESCRIPTION
This initial deny-list includes all repos in ebmdatalab that happen to have old PRs open right now. We can consider a more thorough list if we get more false positives cropping up, but this seems like a cheap way of weeding out most of the repos that we're not interested in and which are currently affecting the charts.

The testing here is pretty half-hearted, but I don't see an easy way to test more thoroughly without significantly restructuring the code. Please feel free to suggest an alternative.