### PR TITLE
Run the grafana workflow every week

### DIFF
--- a/.github/workflows/grafana.yml
+++ b/.github/workflows/grafana.yml
@@ -9,9 +9,9 @@ env:
 
 on:
   workflow_dispatch:
-  push:
-    paths:
-      - 'grafana/*'
+  schedule:
+    # Run every Wednesday at 8am
+    - cron: "0 8 * * 3"
 
 jobs:
   lint-dockerfile:
@@ -34,7 +34,7 @@ jobs:
 
       - name: Build docker image
         run: |
-            just grafana/build 
+            just grafana/build
 
       - name: Run smoke test
         run: |


### PR DESCRIPTION
The grafana workflow isn't running on main after dependabot automerges it at the moment, so this change does a manual check each week until we can figure it out.
    
Fixes: https://github.com/ebmdatalab/metrics/issues/61