### PR TITLE
Manually deploy updates to grafana

### DIFF
--- a/.github/workflows/auto-merge-dependabot-prs.yml
+++ b/.github/workflows/auto-merge-dependabot-prs.yml
@@ -1,6 +1,9 @@
 name: Auto merge Dependabot PRs
 
-on: pull_request
+on:
+  pull_request:
+    paths-ignore:
+      - 'grafana/**'
 
 jobs:
   auto-merge-dependabot-prs:

--- a/.github/workflows/grafana.yml
+++ b/.github/workflows/grafana.yml
@@ -9,9 +9,10 @@ env:
 
 on:
   workflow_dispatch:
-  schedule:
-    # Run every Wednesday at 8am
-    - cron: "0 8 * * 3"
+  push:
+    paths:
+      - 'grafana/**'
+      - '!grafana/README.md'
 
 jobs:
   lint-dockerfile:


### PR DESCRIPTION
We are not able to determine when an update has been made by dependabot and then automatically deploy that change, due to `on: push:` not working with the `paths` option when there's a merge commit.

We are also unable to easily check if grafana has been updated, which means most scheduled runs of the grafana workflow will fail. It means we're unlikely to spot real errors when they happen.

Therefore, we are reverting to manual deployments for now.