### PR TITLE
Run CI on PR and on main

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,7 +9,9 @@ env:
 
 on:
   workflow_dispatch:
+  pull_request:
   push:
+    branches: [main]
 
 jobs:
   check:


### PR DESCRIPTION
This means the CI workflow will only run against a pull request or a commit to main. At the moment, it's running against every branch, which probably isn't needed.