### PR TITLE
Add smoke test

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -144,7 +144,7 @@ jobs:
 
       - name: Test image we imported from previous job works
         run: |
-            SKIP_BUILD=1 just docker-run prod python -m metrics
+            SKIP_BUILD=1 just docker-run prod python -m metrics.tasks.smoke_test
 
       - name: Publish image
         run: |

--- a/metrics/tasks/smoke_test.py
+++ b/metrics/tasks/smoke_test.py
@@ -1,0 +1,14 @@
+import sys
+
+import structlog
+
+
+log = structlog.get_logger()
+
+
+def main():
+    log.info("Smoke test task ran successfully")
+
+
+if __name__ == "__main__":  # pragma: no cover
+    sys.exit(main())


### PR DESCRIPTION
We should have some way of testing that the built image works before deploying it. The previous solution of running the cli tool to output the help message is no longer applicable and we don't want to run any of the tasks that hit an external API, so I've added a task that only prints a log message.