### PR TITLE
Update CMD

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -91,7 +91,7 @@ WORKDIR /app
 
 # We set command rather than entrypoint, to make it easier to run different
 # things from the cli
-CMD ["/opt/venv/bin/python", "-m", "metrics"]
+CMD ["/opt/venv/bin/python", "-m", "metrics.tasks.smoke_test"]
 
 # This may not be necessary, but it probably doesn't hurt
 ENV PYTHONPATH=/app


### PR DESCRIPTION
We removed the Metrics cli, so the default entrypoint for the Docker image has changed. This command is run by Dokku when starting the container. Dokku will only look at whether the command is successful or not. An unsuccessful command will result in the container being restarted, which we want to avoid.  This command is overriden when it's invoked via a Dokku cron job.