### PR TITLE
Record if a repo has vulnerability alerts enabled

### DIFF
--- a/metrics/github/query.py
+++ b/metrics/github/query.py
@@ -26,6 +26,7 @@ def repos(client, org):
           nodes {
             name
             archivedAt
+            hasVulnerabilityAlertsEnabled
           }
           pageInfo {
               endCursor
@@ -43,6 +44,9 @@ def repos(client, org):
                 "org": org,
                 "name": raw_repo["name"],
                 "archived_on": date_from_iso(raw_repo["archivedAt"]),
+                "hasVulnerabilityAlertsEnabled": raw_repo[
+                    "hasVulnerabilityAlertsEnabled"
+                ],
             }
         )
         if tech_owned_repo(repo):

--- a/metrics/github/security.py
+++ b/metrics/github/security.py
@@ -62,17 +62,21 @@ def get_repos(client, org):
 
 
 def vulnerabilities(client, org, to_date):
+    metrics = []
     for repo in get_repos(client, org):
         for day in dates.iter_days(repo.earliest_date(default=to_date), to_date):
             closed_vulns = sum(1 for v in repo.vulnerabilities if v.is_closed_on(day))
             open_vulns = sum(1 for v in repo.vulnerabilities if v.is_open_on(day))
 
-            yield {
-                "time": day,
-                "closed": closed_vulns,
-                "open": open_vulns,
-                "organisation": repo.org,
-                "repo": repo.name,
-                "has_alerts_enabled": repo.has_alerts_enabled,
-                "value": 0,  # needed for the timescaledb
-            }
+            metrics.append(
+                {
+                    "time": day,
+                    "closed": closed_vulns,
+                    "open": open_vulns,
+                    "organisation": repo.org,
+                    "repo": repo.name,
+                    "has_alerts_enabled": repo.has_alerts_enabled,
+                    "value": 0,  # needed for the timescaledb
+                }
+            )
+    return metrics

--- a/metrics/github/security.py
+++ b/metrics/github/security.py
@@ -32,13 +32,16 @@ class Vulnerability:
 class Repo:
     name: str
     org: str
+    has_alerts_enabled: bool
     vulnerabilities: list[Vulnerability]
 
     def __post_init__(self):
         self.vulnerabilities.sort(key=lambda v: v.created_on)
 
-    def earliest_date(self):
-        return self.vulnerabilities[0].created_on
+    def earliest_date(self, default):
+        if self.vulnerabilities:
+            return self.vulnerabilities[0].created_on
+        return default
 
 
 def get_repos(client, org):
@@ -50,13 +53,17 @@ def get_repos(client, org):
         for vuln in query.vulnerabilities(client, repo):
             vulnerabilities.append(Vulnerability.from_dict(vuln))
 
-        if vulnerabilities:
-            yield Repo(repo["name"], repo["org"], vulnerabilities)
+        yield Repo(
+            name=repo["name"],
+            org=repo["org"],
+            has_alerts_enabled=repo["hasVulnerabilityAlertsEnabled"],
+            vulnerabilities=vulnerabilities,
+        )
 
 
 def vulnerabilities(client, org, to_date):
     for repo in get_repos(client, org):
-        for day in dates.iter_days(repo.earliest_date(), to_date):
+        for day in dates.iter_days(repo.earliest_date(default=to_date), to_date):
             closed_vulns = sum(1 for v in repo.vulnerabilities if v.is_closed_on(day))
             open_vulns = sum(1 for v in repo.vulnerabilities if v.is_open_on(day))
 
@@ -66,5 +73,6 @@ def vulnerabilities(client, org, to_date):
                 "open": open_vulns,
                 "organisation": repo.org,
                 "repo": repo.name,
+                "has_alerts_enabled": repo.has_alerts_enabled,
                 "value": 0,  # needed for the timescaledb
             }

--- a/metrics/tasks/vulnerabilities.py
+++ b/metrics/tasks/vulnerabilities.py
@@ -19,11 +19,11 @@ def main():
 
     client = GitHubClient(ebmdatalab_token)
     log.info("Fetching vulnerabilities for ebmdatalab")
-    ebmdatalab_vulns = list(vulnerabilities(client, "ebmdatalab", yesterday))
+    ebmdatalab_vulns = vulnerabilities(client, "ebmdatalab", yesterday)
 
     client = GitHubClient(os_core_token)
     log.info("Fetching vulnerabilities for opensafely-core")
-    os_core_vulns = list(vulnerabilities(client, "opensafely-core", yesterday))
+    os_core_vulns = vulnerabilities(client, "opensafely-core", yesterday)
 
     timescaledb.reset_table(timescaledb.GitHubVulnerabilities)
     timescaledb.write(timescaledb.GitHubVulnerabilities, ebmdatalab_vulns)

--- a/metrics/timescaledb/tables.py
+++ b/metrics/timescaledb/tables.py
@@ -1,4 +1,4 @@
-from sqlalchemy import TIMESTAMP, Column, Integer, MetaData, Table, Text
+from sqlalchemy import TIMESTAMP, Boolean, Column, Integer, MetaData, Table, Text
 
 
 metadata = MetaData()
@@ -24,6 +24,7 @@ GitHubVulnerabilities = Table(
     Column("closed", Integer),
     Column("organisation", Text, primary_key=True),
     Column("repo", Text, primary_key=True),
+    Column("has_alerts_enabled", Boolean),
 )
 
 

--- a/tests/metrics/github/test_security.py
+++ b/tests/metrics/github/test_security.py
@@ -9,6 +9,7 @@ def fake_repos(client, org):
             "org": org,
             "name": "opencodelists",
             "archived_on": None,
+            "hasVulnerabilityAlertsEnabled": True,
         },
         {
             "org": org,
@@ -19,6 +20,7 @@ def fake_repos(client, org):
             "org": org,
             "name": "job-server",
             "archived_on": None,
+            "hasVulnerabilityAlertsEnabled": True,
         },
     ]
 
@@ -78,14 +80,14 @@ def test_get_repos(monkeypatch):
     assert len(result[1].vulnerabilities) == 7
 
 
-def test_get_repos_when_no_vulnerabilities(monkeypatch):
+def test_get_repos_when_no_vulnerabilities_returns_all_nonarchived_repos(monkeypatch):
     monkeypatch.setattr(security.query, "repos", fake_repos)
     monkeypatch.setattr(security.query, "vulnerabilities", lambda x, y: [])
     fake_client = lambda: None  # pragma: no cover
 
     result = list(security.get_repos(fake_client, "test-org"))
 
-    assert len(result) == 0
+    assert len(result) == 2
 
 
 def test_repo_earliest_date():
@@ -93,9 +95,9 @@ def test_repo_earliest_date():
         security.Vulnerability(date(2023, 10, 26), None, None),
         security.Vulnerability(date(2023, 10, 29), None, None),
     ]
-    repo = security.Repo("test", "test-org", vulnerabilities)
+    repo = security.Repo("test", "test-org", True, vulnerabilities)
 
-    assert repo.earliest_date() == date(2023, 10, 26)
+    assert repo.earliest_date(default=None) == date(2023, 10, 26)
 
 
 def test_vulnerability_open_on():
@@ -149,8 +151,8 @@ def test_vulnerabilities(monkeypatch):
             security.Vulnerability(date(2023, 10, 29), None, None),
         ]
         return [
-            security.Repo("test", org, vulnerabilities),
-            security.Repo("test2", org, vulnerabilities),
+            security.Repo("test", org, True, vulnerabilities),
+            security.Repo("test2", org, True, vulnerabilities),
         ]
 
     monkeypatch.setattr(security, "get_repos", fake_repos)
@@ -165,6 +167,7 @@ def test_vulnerabilities(monkeypatch):
         "open": 2,
         "organisation": "test-org",
         "repo": "test",
+        "has_alerts_enabled": True,
     }
     assert result[7] == {
         "time": date(2023, 10, 20),
@@ -173,6 +176,7 @@ def test_vulnerabilities(monkeypatch):
         "open": 1,
         "organisation": "test-org",
         "repo": "test",
+        "has_alerts_enabled": True,
     }
     assert result[33] == {
         "time": date(2023, 10, 29),
@@ -181,4 +185,5 @@ def test_vulnerabilities(monkeypatch):
         "open": 2,
         "organisation": "test-org",
         "repo": "test2",
+        "has_alerts_enabled": True,
     }

--- a/tests/metrics/github/test_security.py
+++ b/tests/metrics/github/test_security.py
@@ -157,7 +157,7 @@ def test_vulnerabilities(monkeypatch):
 
     monkeypatch.setattr(security, "get_repos", fake_repos)
 
-    result = list(security.vulnerabilities({}, "test-org", date(2023, 10, 29)))
+    result = security.vulnerabilities({}, "test-org", date(2023, 10, 29))
 
     assert len(result) == 34
     assert result[0] == {


### PR DESCRIPTION
This records in the Vulnerabilities table whether the repo has Dependabot vulnerability security alerts enabled. Note this isn't the same as whether Dependabot security updates are enabled (i.e whether a PR would be raised for a vulnerability).

As a result of this change, all non-archived repos are stored in the database, rather than only the ones that have had any vulnerabilities.

> [!note]
> We probably want to record additional metadata about a repository and move this information into a separate table at some point. 
> In particular, we should record this information available from the REST API
> ``` json
>"security_and_analysis": {
>   "secret_scanning": {
>         "status": "enabled"
>       },
>       "secret_scanning_push_protection": {
>         "status": "enabled"
>       },
>       "dependabot_security_updates": {
>         "status": "enabled"
>       },
>       "secret_scanning_validity_checks": {
>         "status": "disabled"
>       }
>   }
>   ```