### PR TITLE
Record repo ownership in the database

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -16,8 +16,11 @@ dokku config:set metrics TIMESCALEDB_URL='xxx'
 ```
 
 The `GITHUB_EBMDATALAB_TOKEN` and `GITHUB_OS_CORE_TOKEN` are fine-grained GitHub personal access tokens that are used for authenticating with the GitHub GraphQL API.
-Each token is assigned to a single organisation and should have read access to *all repositories* owned by that organisation with the following repository permissions:
-Code scanning alerts, Dependabot alerts, Metadata, Pull requests and Repository security advisories.
+Each token is assigned to a single organisation and should have the following *read-only* permissions:
+
+* organisation permissions: members
+* *all repositories* owned by the organisation with the following permissions:
+Code scanning alerts, Dependabot alerts, Metadata, Pull requests and Repository security advisories
 
 ## Disable checks
 Dokku performs health checks on apps during deploy by sending requests to port 80.

--- a/metrics/github/client.py
+++ b/metrics/github/client.py
@@ -60,12 +60,11 @@ class GitHubClient:
         check_response(response)
         results = response.json()
 
-        # In some cases graphql will return a 200 response when there are errors.
-        # https://sachee.medium.com/200-ok-error-handling-in-graphql-7ec869aec9bc
-        # Handling things robustly is complex and query specific, so here we simply
-        # take the absence of 'data' as an error, rather than the presence of
-        # 'errors' key.
-        if "data" not in results or not results["data"]:
+        if (
+            "data" not in results
+            or not results["data"]
+            or ("errors" in results and results["errors"])
+        ):
             msg = textwrap.dedent(
                 f"""
                 graphql query failed

--- a/metrics/github/prs.py
+++ b/metrics/github/prs.py
@@ -3,7 +3,7 @@ from datetime import date, datetime, time, timedelta
 
 import structlog
 
-from metrics.github import query
+from metrics.github import query, repos
 from metrics.tools.dates import iter_days
 
 
@@ -28,7 +28,7 @@ def get_metrics(client, orgs):
 def get_prs(client, orgs):
     prs = {}
     for org in orgs:
-        for repo in query.repos(client, org):
+        for repo in repos.tech_repos(client, org):
             prs[repo] = list(query.prs(client, repo))
     return prs
 

--- a/metrics/github/query.py
+++ b/metrics/github/query.py
@@ -26,7 +26,7 @@ def repos(client, org):
     }
     """
     for raw_repo in maybe_truncate(
-        client.get_query(query, path=["organization", "repositories"], org=org)
+        client.graphql_query(query, path=["organization", "repositories"], org=org)
     ):
         yield Repo(
             org,
@@ -68,7 +68,7 @@ def vulnerabilities(client, repo):
     }
     """
 
-    return client.get_query(
+    return client.graphql_query(
         query,
         path=["organization", "repository", "vulnerabilityAlerts"],
         org=repo.org,
@@ -101,7 +101,7 @@ def prs(client, repo):
     }
     """
     for pr in maybe_truncate(
-        client.get_query(
+        client.graphql_query(
             query,
             path=["organization", "repository", "pullRequests"],
             org=repo.org,

--- a/metrics/github/query.py
+++ b/metrics/github/query.py
@@ -3,7 +3,6 @@ import os
 from dataclasses import dataclass
 from datetime import date
 
-from metrics.github.repos import NON_TECH_REPOS
 from metrics.tools.dates import date_from_iso
 
 
@@ -29,15 +28,13 @@ def repos(client, org):
     for raw_repo in maybe_truncate(
         client.get_query(query, path=["organization", "repositories"], org=org)
     ):
-        repo = Repo(
+        yield Repo(
             org,
             raw_repo["name"],
             date_from_iso(raw_repo["createdAt"]),
             date_from_iso(raw_repo["archivedAt"]),
             raw_repo["hasVulnerabilityAlertsEnabled"],
         )
-        if repo.is_tech_owned():
-            yield repo
 
 
 @dataclass(frozen=True)
@@ -47,13 +44,6 @@ class Repo:
     created_on: date
     archived_on: date | None
     has_vulnerability_alerts_enabled: bool = False
-
-    def is_tech_owned(self):
-        # We use a deny-list rather than an allow-list so that newly created repos are treated as
-        # Tech-owned by default, in the hopes of minimizing surprise.
-        return not (
-            self.org in NON_TECH_REPOS and self.name in NON_TECH_REPOS[self.org]
-        )
 
 
 def vulnerabilities(client, repo):

--- a/metrics/github/query.py
+++ b/metrics/github/query.py
@@ -45,6 +45,18 @@ class Repo:
     archived_on: date | None
     has_vulnerability_alerts_enabled: bool = False
 
+    def is_archived(self):
+        return bool(self.archived_on)
+
+
+def team_repos(client, org, team):
+    """The API doesn't make it easy for us to get all the information we need about repos in
+    one place, so we just return a list of repos here and join that to the richer repo objects
+    in the caller."""
+    results = client.rest_query("/orgs/{org}/teams/{team}/repos", org=org, team=team)
+    for repo in results:
+        yield repo["name"]
+
 
 def vulnerabilities(client, repo):
     query = """

--- a/metrics/github/repos.py
+++ b/metrics/github/repos.py
@@ -1,4 +1,17 @@
-NON_TECH_REPOS = {
+from metrics.github import query
+
+
+def tech_repos(client, org):
+    return [r for r in query.repos(client, org) if _is_tech_owned(r)]
+
+
+def _is_tech_owned(repo):
+    # We use a deny-list rather than an allow-list so that newly created repos are treated as
+    # Tech-owned by default, in the hopes of minimizing surprise.
+    return not (repo.org in _NON_TECH_REPOS and repo.name in _NON_TECH_REPOS[repo.org])
+
+
+_NON_TECH_REPOS = {
     "ebmdatalab": [
         "bennett-presentations",
         "bnf-code-to-dmd",

--- a/metrics/github/security.py
+++ b/metrics/github/security.py
@@ -2,7 +2,7 @@ from dataclasses import dataclass
 from datetime import date
 
 from ..tools import dates
-from . import query
+from . import query, repos
 
 
 @dataclass
@@ -31,7 +31,7 @@ class Vulnerability:
 def vulnerabilities(client, org, to_date):
     metrics = []
 
-    for repo in query.repos(client, org):
+    for repo in repos.tech_repos(client, org):
         vulns = list(map(Vulnerability.from_dict, query.vulnerabilities(client, repo)))
 
         end = min(to_date, repo.archived_on) if repo.archived_on else to_date

--- a/metrics/tasks/repos.py
+++ b/metrics/tasks/repos.py
@@ -1,0 +1,33 @@
+import os
+import sys
+
+import structlog
+
+from metrics import timescaledb
+from metrics.github.client import GitHubClient
+from metrics.github.repos import get_repo_ownership
+
+
+log = structlog.get_logger()
+
+
+def main():
+    client = GitHubClient(
+        tokens={
+            "ebmdatalab": os.environ["GITHUB_EBMDATALAB_TOKEN"],
+            "opensafely-core": os.environ["GITHUB_OS_CORE_TOKEN"],
+        }
+    )
+
+    log.info("Getting repos")
+    repos = get_repo_ownership(client, ["ebmdatalab", "opensafely-core"])
+    log.info("Got repos")
+
+    log.info("Writing data")
+    timescaledb.reset_table(timescaledb.GitHubRepos)
+    timescaledb.write(timescaledb.GitHubRepos, repos)
+    log.info("Written data")
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/metrics/timescaledb/__init__.py
+++ b/metrics/timescaledb/__init__.py
@@ -1,8 +1,14 @@
 from .db import reset_table, write
-from .tables import GitHubPullRequests, GitHubVulnerabilities, SlackTechSupport
+from .tables import (
+    GitHubPullRequests,
+    GitHubRepos,
+    GitHubVulnerabilities,
+    SlackTechSupport,
+)
 
 
 __all__ = [
+    "GitHubRepos",
     "GitHubPullRequests",
     "GitHubVulnerabilities",
     "SlackTechSupport",

--- a/metrics/timescaledb/db.py
+++ b/metrics/timescaledb/db.py
@@ -29,7 +29,7 @@ def delete_rows(connection, name, n=10000):
     connection.execute(sql, {"limit": n})
 
 
-def drop_child_tables(connection, name, n=100):
+def drop_child_tables(connection, name):
     sql = text(
         f"""
         SELECT

--- a/metrics/timescaledb/db.py
+++ b/metrics/timescaledb/db.py
@@ -126,13 +126,11 @@ def has_table(engine, table):
 
 
 def has_rows(connection, name):
-    """Count the number of rows in the given table"""
     sql = text(f"SELECT COUNT(*) FROM {name}")
     return connection.scalar(sql) > 0
 
 
 def reset_table(table, engine=None, batch_size=None):
-    """Reset the given Table"""
     if engine is None:
         engine = get_engine()
 

--- a/metrics/timescaledb/db.py
+++ b/metrics/timescaledb/db.py
@@ -148,9 +148,10 @@ def write(table, rows, engine=None):
     if engine is None:
         engine = get_engine()
 
+    max_params = 65535  # limit for postgresql
+    batch_size = max_params // len(table.columns)
+
     with engine.begin() as connection:
-        # batch our values (which are currently up-to-7 item dicts) so we don't
-        # hit the 65535 params limit
-        for values in batched(rows, 9_000):
+        for values in batched(rows, batch_size):
             connection.execute(insert(table).values(values))
             log.info("Inserted %s rows", len(values), table=table.name)

--- a/metrics/timescaledb/tables.py
+++ b/metrics/timescaledb/tables.py
@@ -3,6 +3,16 @@ from sqlalchemy import TIMESTAMP, Boolean, Column, Integer, MetaData, Table, Tex
 
 metadata = MetaData()
 
+
+GitHubRepos = Table(
+    "github_repos",
+    metadata,
+    Column("organisation", Text, primary_key=True),
+    Column("repo", Text, primary_key=True),
+    Column("owner", Text),
+)
+
+
 GitHubPullRequests = Table(
     "github_pull_requests",
     metadata,

--- a/tests/metrics/github/test_repos.py
+++ b/tests/metrics/github/test_repos.py
@@ -1,20 +1,42 @@
 from datetime import date
 
+import pytest
+
+from metrics.github import repos
 from metrics.github.query import Repo
 
 
-def test_dont_filter_out_repos_from_unknown_orgs():
-    assert make_repo(org="other", name="any").is_tech_owned()
+@pytest.fixture
+def patch_query_to_return(monkeypatch):
+    def patch(the_repos):
+        monkeypatch.setattr(repos.query, "repos", lambda *_args: the_repos)
+
+    return patch
 
 
-def test_filtering_of_tech_owned_repos():
-    assert make_repo(org="ebmdatalab", name="metrics").is_tech_owned()
-    assert not make_repo(
-        org="ebmdatalab", name="clinicaltrials-act-tracker"
-    ).is_tech_owned()
+def test_includes_tech_owned_repos(patch_query_to_return):
+    patch_query_to_return(
+        [repo("ebmdatalab", "sysadmin"), repo("opensafely-core", "job-server")]
+    )
+    assert len(repos.tech_repos(None, None)) == 2
 
 
-def make_repo(org, name):
+def test_excludes_non_tech_owned_repos(patch_query_to_return):
+    patch_query_to_return(
+        [
+            repo("ebmdatalab", "clinicaltrials-act-tracker"),
+            repo("opensafely-core", "matching"),
+        ]
+    )
+    assert len(repos.tech_repos(None, None)) == 0
+
+
+def test_dont_exclude_repos_from_unknown_orgs(patch_query_to_return):
+    patch_query_to_return([repo("other", "any")])
+    assert len(repos.tech_repos(None, None)) == 1
+
+
+def repo(org, name):
     return Repo(
         org=org,
         name=name,

--- a/tests/metrics/github/test_repos.py
+++ b/tests/metrics/github/test_repos.py
@@ -7,40 +7,91 @@ from metrics.github.query import Repo
 
 
 @pytest.fixture
-def patch_query_to_return(monkeypatch):
-    def patch(the_repos):
-        monkeypatch.setattr(repos.query, "repos", lambda *_args: the_repos)
+def patch(monkeypatch):
+    def patch(query_func, result):
+        if isinstance(result, list):
+            fake = lambda *_args: result
+        elif isinstance(result, dict):
+
+            def fake(_client, *keys):
+                r = result
+                for key in keys:
+                    r = r[key]
+                return r
+
+        else:
+            raise ValueError
+        monkeypatch.setattr(repos.query, query_func, fake)
 
     return patch
 
 
-def test_includes_tech_owned_repos(patch_query_to_return):
-    patch_query_to_return(
-        [repo("ebmdatalab", "sysadmin"), repo("opensafely-core", "job-server")]
+def test_includes_tech_owned_repos(patch):
+    patch(
+        "repos", [repo("ebmdatalab", "sysadmin"), repo("opensafely-core", "job-server")]
     )
     assert len(repos.tech_repos(None, None)) == 2
 
 
-def test_excludes_non_tech_owned_repos(patch_query_to_return):
-    patch_query_to_return(
+def test_excludes_non_tech_owned_repos(patch):
+    patch(
+        "repos",
         [
             repo("ebmdatalab", "clinicaltrials-act-tracker"),
             repo("opensafely-core", "matching"),
-        ]
+        ],
     )
     assert len(repos.tech_repos(None, None)) == 0
 
 
-def test_dont_exclude_repos_from_unknown_orgs(patch_query_to_return):
-    patch_query_to_return([repo("other", "any")])
+def test_dont_exclude_repos_from_unknown_orgs(patch):
+    patch("repos", [repo("other", "any")])
     assert len(repos.tech_repos(None, None)) == 1
 
 
-def repo(org, name):
+def test_looks_up_ownership(patch):
+    patch("repos", [repo("the_org", "repo1"), repo("the_org", "repo2")])
+    patch("team_repos", {"the_org": {"team-rex": ["repo1"], "team-rap": ["repo2"]}})
+    assert repos.get_repo_ownership(None, ["the_org"]) == [
+        {"organisation": "the_org", "repo": "repo1", "owner": "team-rex"},
+        {"organisation": "the_org", "repo": "repo2", "owner": "team-rap"},
+    ]
+
+
+def test_looks_up_ownership_across_orgs(patch):
+    patch("repos", {"org1": [repo("org1", "repo1")], "org2": [repo("org2", "repo2")]})
+    patch(
+        "team_repos",
+        {
+            "org1": {"team-rex": ["repo1"], "team-rap": []},
+            "org2": {"team-rex": [], "team-rap": ["repo2"]},
+        },
+    )
+    assert repos.get_repo_ownership(None, ["org1", "org2"]) == [
+        {"organisation": "org1", "repo": "repo1", "owner": "team-rex"},
+        {"organisation": "org2", "repo": "repo2", "owner": "team-rap"},
+    ]
+
+
+def test_ignores_ownership_of_archived_repos(patch):
+    patch("repos", [repo("the_org", "the_repo", archived_on=date.min)])
+    patch("team_repos", {"the_org": {"team-rex": ["the_repo"], "team-rap": []}})
+    assert repos.get_repo_ownership(None, ["the_org"]) == []
+
+
+def test_returns_none_for_unknown_ownership(patch):
+    patch("repos", [repo("the_org", "the_repo")])
+    patch("team_repos", {"the_org": {"team-rex": [], "team-rap": []}})
+    assert repos.get_repo_ownership(None, ["the_org"]) == [
+        {"organisation": "the_org", "repo": "the_repo", "owner": None}
+    ]
+
+
+def repo(org, name, archived_on=None):
     return Repo(
         org=org,
         name=name,
         created_on=date.min,
-        archived_on=None,
+        archived_on=archived_on,
         has_vulnerability_alerts_enabled=False,
     )

--- a/tests/metrics/github/test_security.py
+++ b/tests/metrics/github/test_security.py
@@ -59,7 +59,7 @@ def test_vulnerabilities_ignores_archived_repos_after_archive_date(monkeypatch):
             )
         ]
 
-    monkeypatch.setattr(security.query, "repos", fake_repos)
+    monkeypatch.setattr(security.repos, "tech_repos", fake_repos)
 
     def fake_vulnerabilities(client, repo):
         return []
@@ -77,7 +77,7 @@ def test_vulnerabilities(monkeypatch):
             Repo(org, "test2", date(2023, 10, 13), None, True),
         ]
 
-    monkeypatch.setattr(security.query, "repos", fake_repos)
+    monkeypatch.setattr(security.repos, "tech_repos", fake_repos)
 
     def fake_vulnerabilities(client, repo):
         return [

--- a/tests/metrics/timescaledb/test_db.py
+++ b/tests/metrics/timescaledb/test_db.py
@@ -41,12 +41,12 @@ DummyTable = Table(
 
 def test_ensure_table(engine):
     with engine.begin() as connection:
-        assert not has_table(connection, DummyTable.name)
+        assert not has_table(connection, DummyTable)
 
     ensure_table(engine, DummyTable)
 
     with engine.begin() as connection:
-        assert has_table(connection, DummyTable.name)
+        assert has_table(connection, DummyTable)
 
     # check there are timescaledb child tables
     # https://stackoverflow.com/questions/1461722/how-to-find-child-tables-that-inherit-from-another-table-in-psql
@@ -89,14 +89,14 @@ def test_reset_table(engine):
     timescaledb.write(DummyTable, rows, engine=engine)
 
     with engine.begin() as connection:
-        assert has_table(connection, DummyTable.name)
-        assert has_rows(connection, DummyTable.name)
+        assert has_table(connection, DummyTable)
+        assert has_rows(connection, DummyTable)
 
     timescaledb.reset_table(DummyTable, engine=engine, batch_size=batch_size)
 
     with engine.begin() as connection:
-        assert has_table(connection, DummyTable.name)
-        assert not has_rows(connection, DummyTable.name)
+        assert has_table(connection, DummyTable)
+        assert not has_rows(connection, DummyTable)
 
 
 def test_write(engine):

--- a/tests/metrics/timescaledb/test_db.py
+++ b/tests/metrics/timescaledb/test_db.py
@@ -1,5 +1,4 @@
 from datetime import UTC, date, datetime, timedelta
-from unittest.mock import patch
 
 import pytest
 from sqlalchemy import TIMESTAMP, Column, Integer, Table, select, text
@@ -120,12 +119,3 @@ def test_write(engine, table):
     # check rows are in table
     rows = get_rows(engine, table)
     assert len(rows) == 3
-
-
-def test_write_with_default_engine(table):
-    with patch(
-        "metrics.timescaledb.db.get_engine", autospec=True
-    ) as mocked_create_engine:
-        timescaledb.write(table, [])
-
-        mocked_create_engine.assert_called_once()

--- a/tests/metrics/timescaledb/test_db.py
+++ b/tests/metrics/timescaledb/test_db.py
@@ -1,6 +1,7 @@
-from datetime import UTC, date, datetime, timedelta
+from datetime import date, timedelta
 
-from sqlalchemy import TIMESTAMP, Column, Integer, Table, select, text
+import pytest
+from sqlalchemy import TIMESTAMP, Column, Table, Text, select, text
 
 from metrics import timescaledb
 from metrics.timescaledb.db import ensure_table, get_url, has_rows, has_table
@@ -31,26 +32,47 @@ def assert_is_hypertable(engine, table):
     assert result[0] == 1, result
 
 
-DummyTable = Table(
-    "test_table",
-    metadata,
-    Column("time", TIMESTAMP(timezone=True), primary_key=True),
-    Column("value", Integer),
-)
+@pytest.fixture
+def table(request):
+    return Table(
+        f"{request.function.__name__}_table",
+        metadata,
+        Column("value", Text, primary_key=True),
+    )
 
 
-def test_ensure_table(engine):
+@pytest.fixture
+def hypertable(request):
+    return Table(
+        f"{request.function.__name__}_hypertable",
+        metadata,
+        Column("time", TIMESTAMP(timezone=True), primary_key=True),
+        Column("value", Text, primary_key=True),
+    )
+
+
+def test_ensure_table(engine, table):
     with engine.begin() as connection:
-        assert not has_table(connection, DummyTable)
+        assert not has_table(connection, table)
 
-    ensure_table(engine, DummyTable)
+    ensure_table(engine, table)
 
     with engine.begin() as connection:
-        assert has_table(connection, DummyTable)
+        assert has_table(connection, table)
+
+
+def test_ensure_hypertable(engine, hypertable):
+    with engine.begin() as connection:
+        assert not has_table(connection, hypertable)
+
+    ensure_table(engine, hypertable)
+
+    with engine.begin() as connection:
+        assert has_table(connection, hypertable)
 
     # check there are timescaledb child tables
     # https://stackoverflow.com/questions/1461722/how-to-find-child-tables-that-inherit-from-another-table-in-psql
-    assert_is_hypertable(engine, DummyTable)
+    assert_is_hypertable(engine, hypertable)
 
 
 def test_get_url(monkeypatch):
@@ -70,44 +92,52 @@ def test_get_url_with_prefix(monkeypatch):
     assert url.database == "myprefix_db"
 
 
-def test_reset_table(engine):
-    ensure_table(engine, DummyTable)
+def test_reset_table(engine, table):
+    ensure_table(engine, table)
+
+    # put enough rows in the db to make sure we exercise the batch removal of rows
+    batch_size = 5
+    rows = []
+    for i in range(batch_size * 5):
+        rows.append({"value": "reset" + str(i)})
+
+    check_reset(batch_size, engine, rows, table)
+
+
+def test_reset_hypertable(engine, hypertable):
+    ensure_table(engine, hypertable)
 
     # put enough rows in the db to make sure we exercise the batch removal of rows
     batch_size = 5
     rows = []
     start = date(2020, 4, 1)
     for i in range(batch_size * 5):
-        d = start + timedelta(days=i)
-        rows.append(
-            {
-                "time": d,
-                "value": i,
-            }
-        )
+        rows.append({"time": start + timedelta(days=i), "value": "reset" + str(i)})
 
-    timescaledb.write(DummyTable, rows, engine=engine)
+    check_reset(batch_size, engine, rows, hypertable)
+
+
+def check_reset(batch_size, engine, rows, table):
+    timescaledb.write(table, rows, engine=engine)
 
     with engine.begin() as connection:
-        assert has_table(connection, DummyTable)
-        assert has_rows(connection, DummyTable)
+        assert has_table(connection, table)
+        assert has_rows(connection, table)
 
-    timescaledb.reset_table(DummyTable, engine=engine, batch_size=batch_size)
+    timescaledb.reset_table(table, engine=engine, batch_size=batch_size)
 
     with engine.begin() as connection:
-        assert has_table(connection, DummyTable)
-        assert not has_rows(connection, DummyTable)
+        assert has_table(connection, table)
+        assert not has_rows(connection, table)
 
 
-def test_write(engine):
+def test_write(engine, table):
     # set up a table to write to
-    ensure_table(engine, DummyTable)
+    ensure_table(engine, table)
 
-    rows = [
-        {"time": datetime(2023, 11, i, tzinfo=UTC), "value": i} for i in range(1, 4)
-    ]
-    timescaledb.write(DummyTable, rows, engine=engine)
+    rows = [{"value": "write" + str(i)} for i in range(1, 4)]
+    timescaledb.write(table, rows, engine=engine)
 
     # check rows are in table
-    rows = get_rows(engine, DummyTable)
+    rows = get_rows(engine, table)
     assert len(rows) == 3

--- a/tests/metrics/timescaledb/test_db.py
+++ b/tests/metrics/timescaledb/test_db.py
@@ -12,7 +12,7 @@ def get_rows(engine, table):
         return connection.execute(select(table)).all()
 
 
-def is_hypertable(engine, table):
+def assert_is_hypertable(engine, table):
     sql = """
     SELECT
       count(*)
@@ -50,7 +50,7 @@ def test_ensure_table(engine):
 
     # check there are timescaledb child tables
     # https://stackoverflow.com/questions/1461722/how-to-find-child-tables-that-inherit-from-another-table-in-psql
-    is_hypertable(engine, DummyTable)
+    assert_is_hypertable(engine, DummyTable)
 
 
 def test_get_url(monkeypatch):

--- a/tests/metrics/timescaledb/test_db.py
+++ b/tests/metrics/timescaledb/test_db.py
@@ -73,8 +73,7 @@ def test_get_url_with_prefix(monkeypatch):
 def test_reset_table(engine):
     ensure_table(engine, DummyTable)
 
-    # put enough rows in the db to make sure we exercise the batch removal of
-    # rows.  timescaledb's write() will ensure the table exists for us.
+    # put enough rows in the db to make sure we exercise the batch removal of rows
     batch_size = 5
     rows = []
     start = date(2020, 4, 1)

--- a/tests/metrics/timescaledb/test_db.py
+++ b/tests/metrics/timescaledb/test_db.py
@@ -75,9 +75,10 @@ def test_reset_table(engine):
 
     # put enough rows in the db to make sure we exercise the batch removal of
     # rows.  timescaledb's write() will ensure the table exists for us.
+    batch_size = 5
     rows = []
     start = date(2020, 4, 1)
-    for i in range(11_000):
+    for i in range(batch_size * 5):
         d = start + timedelta(days=i)
         rows.append(
             {
@@ -92,7 +93,7 @@ def test_reset_table(engine):
         assert has_table(connection, DummyTable.name)
         assert has_rows(connection, DummyTable.name)
 
-    timescaledb.reset_table(DummyTable, engine=engine)
+    timescaledb.reset_table(DummyTable, engine=engine, batch_size=batch_size)
 
     with engine.begin() as connection:
         assert has_table(connection, DummyTable.name)

--- a/tests/metrics/tools/test_dates.py
+++ b/tests/metrics/tools/test_dates.py
@@ -28,14 +28,3 @@ def test_iter_days():
         date(2020, 7, 9),
         date(2020, 7, 10),
     ]
-
-
-def test_iter_days_with_empty_values():
-    with pytest.raises(TypeError):
-        list(iter_days(None, date(2020, 7, 8)))
-
-    with pytest.raises(TypeError):
-        list(iter_days(date(2020, 7, 8), None))
-
-    with pytest.raises(TypeError):
-        list(iter_days(date(2020, 7, 8), date(2022, 7, 8), None))


### PR DESCRIPTION
This introduces a task `metrics repos`, which doesn't strictly deal in metrics (it writes plain old tabular data that can be used for showing useful data on our delivery dashboard). I think that's probably okay, but worth double-checking that we are happy with this use.

(The thing I'm planning to do with this data is add a table of unowned repos. Currently I have a shell script that I use to check this monthly so that I can chase people up when they create new repos and forget to assign them to a team in GitHub.)

![image](https://github.com/ebmdatalab/metrics/assets/128750/92b62da9-002f-4952-90b8-1b37b99cfd56)

We need to add permissions to the PAT used in production before deploying this change.