### PR TITLE
Rework layering for GitHub logic

### DIFF
--- a/metrics/github/issues.py
+++ b/metrics/github/issues.py
@@ -5,7 +5,7 @@ from dataclasses import dataclass
 import structlog
 
 from metrics.github import query, repos
-from metrics.github.query import Repo
+from metrics.github.repos import Repo
 from metrics.tools.dates import date_from_iso, iter_days
 
 

--- a/metrics/github/issues.py
+++ b/metrics/github/issues.py
@@ -1,13 +1,32 @@
 import datetime
 from collections import defaultdict
+from dataclasses import dataclass
 
 import structlog
 
 from metrics.github import query, repos
-from metrics.tools.dates import iter_days
+from metrics.github.query import Repo
+from metrics.tools.dates import date_from_iso, iter_days
 
 
 log = structlog.get_logger()
+
+
+@dataclass(frozen=True)
+class Issue:
+    repo: Repo
+    author: str
+    created_on: datetime.date
+    closed_on: datetime.date
+
+    @classmethod
+    def from_dict(cls, data, repo):
+        return cls(
+            repo,
+            data["author"]["login"],
+            date_from_iso(data["createdAt"]),
+            date_from_iso(data["closedAt"]),
+        )
 
 
 def get_metrics(client, orgs):
@@ -24,7 +43,7 @@ def get_issues(client, orgs):
     issues = []
     for org in orgs:
         for repo in repos.tech_repos(client, org):
-            issues.extend(query.issues(client, repo))
+            issues.extend(Issue.from_dict(i, repo) for i in query.issues(client, repo))
     return issues
 
 

--- a/metrics/github/query.py
+++ b/metrics/github/query.py
@@ -149,28 +149,14 @@ def issues(client, repo):
       }
     }
     """
-    for issue in maybe_truncate(
+    return maybe_truncate(
         client.graphql_query(
             query,
             path=["organization", "repository", "issues"],
             org=repo.org,
             repo=repo.name,
         )
-    ):
-        yield Issue(
-            repo,
-            issue["author"]["login"],
-            date_from_iso(issue["createdAt"]),
-            date_from_iso(issue["closedAt"]),
-        )
-
-
-@dataclass(frozen=True)
-class Issue:
-    repo: Repo
-    author: str
-    created_on: date
-    closed_on: date
+    )
 
 
 def maybe_truncate(it):

--- a/metrics/github/query.py
+++ b/metrics/github/query.py
@@ -1,7 +1,5 @@
 import itertools
 import os
-from dataclasses import dataclass
-from datetime import date
 
 from metrics.tools.dates import date_from_iso
 
@@ -25,25 +23,9 @@ def repos(client, org):
       }
     }
     """
-    for raw_repo in maybe_truncate(
+    return maybe_truncate(
         client.graphql_query(query, path=["organization", "repositories"], org=org)
-    ):
-        yield Repo(
-            org,
-            raw_repo["name"],
-            date_from_iso(raw_repo["createdAt"]),
-            raw_repo["archivedAt"] is not None,
-            raw_repo["hasVulnerabilityAlertsEnabled"],
-        )
-
-
-@dataclass(frozen=True)
-class Repo:
-    org: str
-    name: str
-    created_on: date
-    is_archived: bool = False
-    has_vulnerability_alerts_enabled: bool = False
+    )
 
 
 def team_repos(client, org, team):

--- a/metrics/github/repos.py
+++ b/metrics/github/repos.py
@@ -14,6 +14,10 @@ class Repo:
     is_archived: bool = False
     has_vulnerability_alerts_enabled: bool = False
 
+    @property
+    def is_tech_owned(self):
+        return self.team in _TECH_TEAMS
+
     @classmethod
     def from_dict(cls, data, org, team):
         return cls(
@@ -27,7 +31,7 @@ class Repo:
 
 
 def tech_repos(client, org):
-    return [r for r in _active_repos(client, org) if r.team in _TECH_TEAMS]
+    return [r for r in _active_repos(client, org) if r.is_tech_owned]
 
 
 def get_repo_ownership(client, orgs):

--- a/metrics/github/repos.py
+++ b/metrics/github/repos.py
@@ -38,18 +38,6 @@ def all_repos(client, org):
     return _active_repos(client, org)
 
 
-def get_repo_ownership(client, orgs):
-    repo_owners = []
-
-    for org in orgs:
-        for repo in _active_repos(client, org):
-            repo_owners.append(
-                {"organisation": repo.org, "repo": repo.name, "owner": repo.team}
-            )
-
-    return repo_owners
-
-
 def _active_repos(client, org):
     return [repo for repo in _get_repos(client, org) if not repo.is_archived]
 

--- a/metrics/github/repos.py
+++ b/metrics/github/repos.py
@@ -27,25 +27,17 @@ class Repo:
 
 
 def tech_repos(client, org):
-    repo_names = []
-    for team in _TECH_TEAMS:
-        repo_names.extend(query.team_repos(client, org, team))
-
-    return [r for r in _active_repos(client, org) if r.name in repo_names]
+    return [r for r in _active_repos(client, org) if r.team in _TECH_TEAMS]
 
 
 def get_repo_ownership(client, orgs):
     repo_owners = []
 
     for org in orgs:
-        ownership = _repo_owners(client, org)
-
         for repo in _active_repos(client, org):
-            if repo.name in ownership:
-                team = ownership[repo.name]
-            else:
-                team = None
-            repo_owners.append({"organisation": org, "repo": repo.name, "owner": team})
+            repo_owners.append(
+                {"organisation": repo.org, "repo": repo.name, "owner": repo.team}
+            )
 
     return repo_owners
 

--- a/metrics/github/repos.py
+++ b/metrics/github/repos.py
@@ -9,15 +9,17 @@ from metrics.tools.dates import date_from_iso
 class Repo:
     org: str
     name: str
+    team: str
     created_on: date
     is_archived: bool = False
     has_vulnerability_alerts_enabled: bool = False
 
     @classmethod
-    def from_dict(cls, data, org):
+    def from_dict(cls, data, org, team):
         return cls(
             org,
             data["name"],
+            team,
             date_from_iso(data["createdAt"]),
             data["archivedAt"] is not None,
             data["hasVulnerabilityAlertsEnabled"],
@@ -36,10 +38,7 @@ def get_repo_ownership(client, orgs):
     repo_owners = []
 
     for org in orgs:
-        ownership = {}
-        for team in _TECH_TEAMS:
-            for repo in query.team_repos(client, org, team):
-                ownership[repo] = team
+        ownership = _repo_owners(client, org)
 
         for repo in _active_repos(client, org):
             if repo.name in ownership:
@@ -56,8 +55,20 @@ def _active_repos(client, org):
 
 
 def _all_repos(client, org):
-    repos = query.repos(client, org)
-    return [Repo.from_dict(r, org) for r in repos]
+    ownership = _repo_owners(client, org)
+    repos = []
+    for repo in query.repos(client, org):
+        owner = ownership.get(repo["name"])
+        repos.append(Repo.from_dict(repo, org, owner))
+    return repos
+
+
+def _repo_owners(client, org):
+    ownership = {}
+    for team in _TECH_TEAMS:
+        for repo in query.team_repos(client, org, team):
+            ownership[repo] = team
+    return ownership
 
 
 # GitHub slugs for the teams we're interested in

--- a/metrics/github/repos.py
+++ b/metrics/github/repos.py
@@ -34,6 +34,10 @@ def tech_repos(client, org):
     return [r for r in _active_repos(client, org) if r.is_tech_owned]
 
 
+def all_repos(client, org):
+    return _active_repos(client, org)
+
+
 def get_repo_ownership(client, orgs):
     repo_owners = []
 
@@ -47,10 +51,10 @@ def get_repo_ownership(client, orgs):
 
 
 def _active_repos(client, org):
-    return [repo for repo in _all_repos(client, org) if not repo.is_archived]
+    return [repo for repo in _get_repos(client, org) if not repo.is_archived]
 
 
-def _all_repos(client, org):
+def _get_repos(client, org):
     ownership = _repo_owners(client, org)
     repos = []
     for repo in query.repos(client, org):

--- a/tests/metrics/github/test_issues.py
+++ b/tests/metrics/github/test_issues.py
@@ -13,7 +13,7 @@ TWO_DAYS_AGO = date(year=2023, month=6, day=8)
 
 pytestmark = pytest.mark.freeze_time(TODAY)
 
-REPO = Repo("the-org", "the-repo", created_on=date.min)
+REPO = Repo("the-org", "the-repo", "the-team", created_on=date.min)
 AUTHOR = "author"
 
 
@@ -103,6 +103,7 @@ def repo(org, name, is_archived=False):
     return Repo(
         org,
         name,
+        "a-team",
         created_on=date.min,
         is_archived=is_archived,
         has_vulnerability_alerts_enabled=False,

--- a/tests/metrics/github/test_issues.py
+++ b/tests/metrics/github/test_issues.py
@@ -2,8 +2,8 @@ from datetime import date
 
 import pytest
 
-from metrics.github.issues import calculate_counts
-from metrics.github.query import Issue, Repo
+from metrics.github.issues import Issue, calculate_counts
+from metrics.github.query import Repo
 
 
 TODAY = date(year=2023, month=6, day=10)

--- a/tests/metrics/github/test_issues.py
+++ b/tests/metrics/github/test_issues.py
@@ -3,7 +3,7 @@ from datetime import date
 import pytest
 
 from metrics.github.issues import Issue, calculate_counts
-from metrics.github.query import Repo
+from metrics.github.repos import Repo
 
 
 TODAY = date(year=2023, month=6, day=10)

--- a/tests/metrics/github/test_prs.py
+++ b/tests/metrics/github/test_prs.py
@@ -129,6 +129,7 @@ def repo(org, name, is_archived=False):
     return Repo(
         org,
         name,
+        "a-team",
         created_on=date.min,
         is_archived=is_archived,
         has_vulnerability_alerts_enabled=False,

--- a/tests/metrics/github/test_prs.py
+++ b/tests/metrics/github/test_prs.py
@@ -3,7 +3,7 @@ from datetime import date, timedelta
 import pytest
 
 from metrics.github.prs import calculate_counts, is_old, was_merged_on
-from metrics.github.query import Repo
+from metrics.github.repos import Repo
 
 
 TODAY = date(year=2023, month=6, day=10)

--- a/tests/metrics/github/test_repos.py
+++ b/tests/metrics/github/test_repos.py
@@ -1,9 +1,8 @@
-from datetime import date
+import datetime
 
 import pytest
 
 from metrics.github import repos
-from metrics.github.query import Repo
 
 
 @pytest.fixture
@@ -40,10 +39,10 @@ def test_includes_tech_owned_repos(patch):
     patch(
         "repos",
         [
-            repo("opensafely-core", "ehrql"),
-            repo("opensafely-core", "cohort-extractor"),
-            repo("opensafely-core", "job-server"),
-            repo("opensafely-core", ".github"),
+            repo("ehrql"),
+            repo("cohort-extractor"),
+            repo("job-server"),
+            repo(".github"),
         ],
     )
     assert len(repos.tech_repos(None, "opensafely-core")) == 4
@@ -57,7 +56,7 @@ def test_excludes_non_tech_owned_repos(patch):
     patch(
         "repos",
         [
-            repo("opensafely-core", "other-repo"),
+            repo("other-repo"),
         ],
     )
     assert len(repos.tech_repos(None, "opensafely-core")) == 0
@@ -77,7 +76,7 @@ def test_excludes_archived_repos(patch):
     patch(
         "repos",
         [
-            repo("opensafely-core", "other-repo", is_archived=True),
+            repo("other-repo", is_archived=True),
         ],
     )
     assert len(repos.tech_repos(None, "opensafely-core")) == 0
@@ -86,7 +85,7 @@ def test_excludes_archived_repos(patch):
 def test_looks_up_ownership(patch):
     patch(
         "repos",
-        [repo("the_org", "repo1"), repo("the_org", "repo2"), repo("the_org", "repo3")],
+        [repo("repo1"), repo("repo2"), repo("repo3")],
     )
     patch(
         "team_repos",
@@ -106,7 +105,7 @@ def test_looks_up_ownership(patch):
 
 
 def test_looks_up_ownership_across_orgs(patch):
-    patch("repos", {"org1": [repo("org1", "repo1")], "org2": [repo("org2", "repo2")]})
+    patch("repos", {"org1": [repo("repo1")], "org2": [repo("repo2")]})
     patch(
         "team_repos",
         {
@@ -121,7 +120,7 @@ def test_looks_up_ownership_across_orgs(patch):
 
 
 def test_ignores_ownership_of_archived_repos(patch):
-    patch("repos", [repo("the_org", "the_repo", is_archived=True)])
+    patch("repos", [repo("the_repo", is_archived=True)])
     patch(
         "team_repos",
         {"the_org": {"team-rex": ["the_repo"], "team-rap": [], "tech-shared": []}},
@@ -130,7 +129,7 @@ def test_ignores_ownership_of_archived_repos(patch):
 
 
 def test_returns_none_for_unknown_ownership(patch):
-    patch("repos", [repo("the_org", "the_repo")])
+    patch("repos", [repo("the_repo")])
     patch(
         "team_repos", {"the_org": {"team-rex": [], "team-rap": [], "tech-shared": []}}
     )
@@ -139,11 +138,10 @@ def test_returns_none_for_unknown_ownership(patch):
     ]
 
 
-def repo(org, name, is_archived=False):
-    return Repo(
-        org=org,
+def repo(name, is_archived=False):
+    return dict(
         name=name,
-        created_on=date.min,
-        is_archived=is_archived,
-        has_vulnerability_alerts_enabled=False,
+        createdAt=datetime.datetime.min.isoformat(),
+        archivedAt=datetime.datetime.now().isoformat() if is_archived else None,
+        hasVulnerabilityAlertsEnabled=False,
     )

--- a/tests/metrics/github/test_repos.py
+++ b/tests/metrics/github/test_repos.py
@@ -3,6 +3,7 @@ import datetime
 import pytest
 
 from metrics.github import repos
+from metrics.github.repos import Repo
 
 
 @pytest.fixture
@@ -39,10 +40,10 @@ def test_includes_tech_owned_repos(patch):
     patch(
         "repos",
         [
-            repo("ehrql"),
-            repo("cohort-extractor"),
-            repo("job-server"),
-            repo(".github"),
+            repo_data("ehrql"),
+            repo_data("cohort-extractor"),
+            repo_data("job-server"),
+            repo_data(".github"),
         ],
     )
     assert len(repos.tech_repos(None, "opensafely-core")) == 4
@@ -56,13 +57,13 @@ def test_excludes_non_tech_owned_repos(patch):
     patch(
         "repos",
         [
-            repo("other-repo"),
+            repo_data("other-repo"),
         ],
     )
     assert len(repos.tech_repos(None, "opensafely-core")) == 0
 
 
-def test_excludes_archived_repos(patch):
+def test_excludes_archived_tech_repos(patch):
     patch(
         "team_repos",
         {
@@ -76,7 +77,7 @@ def test_excludes_archived_repos(patch):
     patch(
         "repos",
         [
-            repo("other-repo", is_archived=True),
+            repo_data("other-repo", is_archived=True),
         ],
     )
     assert len(repos.tech_repos(None, "opensafely-core")) == 0
@@ -85,7 +86,7 @@ def test_excludes_archived_repos(patch):
 def test_looks_up_ownership(patch):
     patch(
         "repos",
-        [repo("repo1"), repo("repo2"), repo("repo3")],
+        [repo_data("repo1"), repo_data("repo2"), repo_data("repo3")],
     )
     patch(
         "team_repos",
@@ -97,51 +98,38 @@ def test_looks_up_ownership(patch):
             }
         },
     )
-    assert repos.get_repo_ownership(None, ["the_org"]) == [
-        {"organisation": "the_org", "repo": "repo1", "owner": "team-rex"},
-        {"organisation": "the_org", "repo": "repo2", "owner": "team-rap"},
-        {"organisation": "the_org", "repo": "repo3", "owner": "tech-shared"},
+    assert repos.all_repos(None, "the_org") == [
+        repo("the_org", "repo1", "team-rex"),
+        repo("the_org", "repo2", "team-rap"),
+        repo("the_org", "repo3", "tech-shared"),
     ]
 
 
-def test_looks_up_ownership_across_orgs(patch):
-    patch("repos", {"org1": [repo("repo1")], "org2": [repo("repo2")]})
+def test_excludes_archived_non_tech_repos(patch):
+    patch("repos", [repo_data("the_repo", is_archived=True)])
     patch(
         "team_repos",
-        {
-            "org1": {"team-rex": ["repo1"], "team-rap": [], "tech-shared": []},
-            "org2": {"team-rex": [], "team-rap": ["repo2"], "tech-shared": []},
-        },
+        {"the_org": {"team-rex": [], "team-rap": [], "tech-shared": []}},
     )
-    assert repos.get_repo_ownership(None, ["org1", "org2"]) == [
-        {"organisation": "org1", "repo": "repo1", "owner": "team-rex"},
-        {"organisation": "org2", "repo": "repo2", "owner": "team-rap"},
-    ]
-
-
-def test_ignores_ownership_of_archived_repos(patch):
-    patch("repos", [repo("the_repo", is_archived=True)])
-    patch(
-        "team_repos",
-        {"the_org": {"team-rex": ["the_repo"], "team-rap": [], "tech-shared": []}},
-    )
-    assert repos.get_repo_ownership(None, ["the_org"]) == []
+    assert repos.all_repos(None, "the_org") == []
 
 
 def test_returns_none_for_unknown_ownership(patch):
-    patch("repos", [repo("the_repo")])
+    patch("repos", [repo_data("the_repo")])
     patch(
         "team_repos", {"the_org": {"team-rex": [], "team-rap": [], "tech-shared": []}}
     )
-    assert repos.get_repo_ownership(None, ["the_org"]) == [
-        {"organisation": "the_org", "repo": "the_repo", "owner": None}
-    ]
+    assert repos.all_repos(None, "the_org") == [repo("the_org", "the_repo", None)]
 
 
-def repo(name, is_archived=False):
+def repo_data(name, is_archived=False):
     return dict(
         name=name,
         createdAt=datetime.datetime.min.isoformat(),
         archivedAt=datetime.datetime.now().isoformat() if is_archived else None,
         hasVulnerabilityAlertsEnabled=False,
     )
+
+
+def repo(org, name, team):
+    return Repo(org, name, team, datetime.date.min)

--- a/tests/metrics/github/test_security.py
+++ b/tests/metrics/github/test_security.py
@@ -1,7 +1,7 @@
 from datetime import date
 
 from metrics.github import security
-from metrics.github.query import Repo
+from metrics.github.repos import Repo
 
 
 def test_vulnerability_open_on():

--- a/tests/metrics/github/test_security.py
+++ b/tests/metrics/github/test_security.py
@@ -49,8 +49,8 @@ def test_vulnerability_closed_on_is_closed():
 def test_vulnerabilities(monkeypatch):
     def fake_repos(client, org):
         return [
-            Repo(org, "test", date(2023, 10, 13), False, True),
-            Repo(org, "test2", date(2023, 10, 13), False, True),
+            Repo(org, "test", "a-team", date(2023, 10, 13), False, True),
+            Repo(org, "test2", "a-team", date(2023, 10, 13), False, True),
         ]
 
     monkeypatch.setattr(security.repos, "tech_repos", fake_repos)


### PR DESCRIPTION
This PR moves the creation of domain objects up a layer and leaves `query` dealing only in untyped dicts. The motivation is that this allows us to have richer domain objects that are the result of more than one API call. In particular here we add owning team information to the `Repo` objects; we're then able to remove duplication in handling of that ownership information.

This makes `github.repos` a richer module which captures our understanding and use of GitHub. The datatype conversion from domain objects to dicts for writing to the database doesn't fit easily there, so it's moved out into the task module.

I anticipate making similar refactorings for `issues`, `prs`, `security`. In those cases we'll be moving out not just simple conversions but calculation of more complex metrics, which I think it definitely makes sense to separate from the domain logic.