### PR TITLE
Add scope to workflow `deploy` `concurrency` keys

### DIFF
--- a/.github/workflows/grafana.yml
+++ b/.github/workflows/grafana.yml
@@ -79,7 +79,7 @@ jobs:
 
     if: github.ref == 'refs/heads/main'
 
-    concurrency: deploy-production
+    concurrency: deploy-production-grafana
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -148,7 +148,7 @@ jobs:
 
     if: github.ref == 'refs/heads/main'
 
-    concurrency: deploy-production
+    concurrency: deploy-production-ci
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Make the `deploy` job `concurrency` keys for unrelated GitHub Actions workflows use distinct `concurrency` keys. The two workflows relate to separate production environments so there is no particular reason they shouldn't run at the same time. Moreover, sharing keys sometimes leads to jobs in one workflow being cancelled due to the state of jobs in the other workflow, which is undesirable.

[The docs](https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/control-the-concurrency-of-workflows-and-jobs) explain how this can happen:

> When a concurrent job or workflow is queued, if another job or workflow using the same concurrency group in the repository is in progress, the queued job or workflow will be pending. Any existing pending job or workflow in the same concurrency group, if it exists, will be canceled and the new queued job or workflow will take its place.

This could occur for example with the following sequence:

* A CI deploy job is in progress.
* A Grafana deploy job is initiated and queued due to the concurrency key matching the CI deploy job.
* A second CI deploy job is initiated, cancelling the queued Grafana job and becoming the only queued job.

For example, the following runs seem to exhibit this issue:

- https://github.com/ebmdatalab/metrics/actions/runs/10668273871
- https://github.com/ebmdatalab/metrics/actions/runs/8420361809
- https://github.com/ebmdatalab/metrics/actions/runs/8234662934