### PR TITLE
Include flags for unpushed and uncommitted changes, plus deleted flag

### DIFF
--- a/metrics/github/github.py
+++ b/metrics/github/github.py
@@ -115,6 +115,8 @@ class Codespace:
     user: str
     created_at: datetime.datetime
     last_used_at: datetime.datetime
+    has_uncommitted_changes: bool
+    has_unpushed_changes: bool
 
     @classmethod
     def from_dict(cls, data, org):
@@ -124,6 +126,8 @@ class Codespace:
             user=data["owner"]["login"],
             created_at=data["created_at"],
             last_used_at=data["last_used_at"],
+            has_uncommitted_changes=data["git_status"]["has_uncommitted_changes"],
+            has_unpushed_changes=data["git_status"]["has_unpushed_changes"],
         )
 
 

--- a/metrics/github/github.py
+++ b/metrics/github/github.py
@@ -117,6 +117,7 @@ class Codespace:
     last_used_at: datetime.datetime
     has_uncommitted_changes: bool
     has_unpushed_changes: bool
+    deleted: bool
 
     @classmethod
     def from_dict(cls, data, org):
@@ -128,6 +129,7 @@ class Codespace:
             last_used_at=data["last_used_at"],
             has_uncommitted_changes=data["git_status"]["has_uncommitted_changes"],
             has_unpushed_changes=data["git_status"]["has_unpushed_changes"],
+            deleted=False,
         )
 
 

--- a/metrics/github/metrics.py
+++ b/metrics/github/metrics.py
@@ -87,6 +87,7 @@ def convert_codespaces_to_dicts(codespaces):
             "last_used_at": c.last_used_at,
             "has_uncommitted_changes": c.has_uncommitted_changes,
             "has_unpushed_changes": c.has_unpushed_changes,
+            "deleted": c.deleted,
         }
         for c in codespaces
     ]

--- a/metrics/github/metrics.py
+++ b/metrics/github/metrics.py
@@ -85,6 +85,8 @@ def convert_codespaces_to_dicts(codespaces):
             "user": c.user,
             "created_at": c.created_at,
             "last_used_at": c.last_used_at,
+            "has_uncommitted_changes": c.has_uncommitted_changes,
+            "has_unpushed_changes": c.has_unpushed_changes,
         }
         for c in codespaces
     ]

--- a/metrics/tasks/codespaces.py
+++ b/metrics/tasks/codespaces.py
@@ -15,6 +15,12 @@ def main():
     codespaces = github.codespaces(org="opensafely")
     log.info(f"Got {len(codespaces)} codespaces")
 
+    log.info("Flagging old codespaces as deleted")
+    db.flag_deleted(tables.GitHubCodespaces)
+    log.info("Deletes flagged")
+
+    # Incoming data has deleted=False so previously flagged rows will be overwritten
+    # if codespace still exists.
     log.info("Writing data")
     db.upsert(tables.GitHubCodespaces, convert_codespaces_to_dicts(codespaces))
     log.info("Written data")

--- a/metrics/timescaledb/tables.py
+++ b/metrics/timescaledb/tables.py
@@ -12,6 +12,8 @@ GitHubCodespaces = Table(
     Column("repo", Text, primary_key=True),
     Column("user", Text, primary_key=True),
     Column("last_used_at", TIMESTAMP(timezone=True)),
+    Column("has_uncommitted_changes", Boolean),
+    Column("has_unpushed_changes", Boolean),
 )
 
 GitHubRepos = Table(

--- a/metrics/timescaledb/tables.py
+++ b/metrics/timescaledb/tables.py
@@ -14,6 +14,7 @@ GitHubCodespaces = Table(
     Column("last_used_at", TIMESTAMP(timezone=True)),
     Column("has_uncommitted_changes", Boolean),
     Column("has_unpushed_changes", Boolean),
+    Column("deleted", Boolean, nullable=False, default=False),
 )
 
 GitHubRepos = Table(

--- a/tests/metrics/github/test_github.py
+++ b/tests/metrics/github/test_github.py
@@ -45,6 +45,10 @@ def test_codespaces(patch):
                     "repository": {"name": "testrepo"},
                     "created_at": datetime.datetime.now().isoformat(),
                     "last_used_at": datetime.datetime.now().isoformat(),
+                    "git_status": {
+                        "has_uncommitted_changes": True,
+                        "has_unpushed_changes": False,
+                    },
                 },
             ]
         },


### PR DESCRIPTION
Forms part of https://github.com/opensafely-core/research-template-docker/issues/70

Record which codespaces have uncommited and/or unpushed changes in order to support reporting on which codespaces users might be at risk of losing data upon codespace deletion.

Once deployed, grafana dashboard will be written to show codespaces near to end of retention period with unpushed/committed changes.

Since the codespaces table is a persistent table (unlike the others) and this PR adds some new columns, we need some sort of way of migrating the database changes. This PR includes a very basic implementation of such a migration, without needing to reach for something more full-featured like Alembic.