### PR TITLE
Remove use of app token

### DIFF
--- a/.github/workflows/update-dependencies.yml
+++ b/.github/workflows/update-dependencies.yml
@@ -15,12 +15,4 @@ jobs:
         python-version: "3.12"
         install-just: true
 
-    - uses: actions/create-github-app-token@v1
-      id: generate-token
-      with:
-        app-id: 1031449  # opensafely-core Create PR app
-        private-key: ${{ secrets.CREATE_PR_APP_PRIVATE_KEY }}
-
     - uses: opensafely-core/update-dependencies-action@v1
-      with:
-        token: ${{ steps.generate-token.outputs.token }}


### PR DESCRIPTION
From the update-dependencies workflow.

It's not clear whether, or how, we should trigger CI workflows automatically in this context.

The impact is that any automatically generated PR by this workflow will need to be manually closed and re-opened to trigger a CI run.

See the [related Slack discussion](https://bennettoxford.slack.com/archives/C63UXGB8E/p1729848644245769).