### PR TITLE
Turn off automerge of updates

### DIFF
--- a/.github/workflows/update-dependencies.yml
+++ b/.github/workflows/update-dependencies.yml
@@ -3,7 +3,7 @@ name: Update python dependencies
 on:
   workflow_dispatch:
   schedule:
-    - cron:  "5 6 * * *"
+    - cron:  "5 6 * * MON"
 
 jobs:
   update-dependencies:
@@ -24,3 +24,4 @@ jobs:
     - uses: opensafely-core/update-dependencies-action@v1
       with:
         token: ${{ steps.generate-token.outputs.token }}
+        automerge: false


### PR DESCRIPTION
Before replacing dependabot with a custom action, we were manually approving PRs. I don't believe the change to a custom action was intended to change that behaviour. There are additional security concerns that we should consider before moving to automerge any updates.

Given that we review dependabot PRs once a week, I've also changed the workflow to run weekly rather than daily (as dependabot was doing previously).