### PR TITLE
Add Create PR App ID secret

### DIFF
--- a/.github/workflows/update-dependencies.yml
+++ b/.github/workflows/update-dependencies.yml
@@ -18,7 +18,7 @@ jobs:
     - uses: actions/create-github-app-token@v1
       id: generate-token
       with:
-        app-id: 1031449  # opensafely-core Create PR app
+        app-id: ${{ secrets.CREATE_PR_APP_ID }}
         private-key: ${{ secrets.CREATE_PR_APP_PRIVATE_KEY }}
 
     - uses: opensafely-core/update-dependencies-action@v1


### PR DESCRIPTION
I've created a GitHub app to manage the permissions needed for the Create PR action. The app id has been stored as a secret that's available to this repo.

Fixes #250.