### PR TITLE
Correct metrics for auto-dismissed vulnerabilities

### DIFF
--- a/metrics/github/query.py
+++ b/metrics/github/query.py
@@ -56,6 +56,7 @@ def vulnerabilities(org, repo):
               createdAt
               fixedAt
               dismissedAt
+              autoDismissedAt
             }
             pageInfo {
               endCursor

--- a/metrics/github/security.py
+++ b/metrics/github/security.py
@@ -10,13 +10,19 @@ class Vulnerability:
     created_on: datetime.date
     fixed_on: datetime.date | None
     dismissed_on: datetime.date | None
+    auto_dismissed_on: datetime.date | None
 
     def is_open_on(self, target_date):
         return self.created_on <= target_date and not self.is_closed_on(target_date)
 
     def is_closed_on(self, target_date):
-        return (self.fixed_on is not None and self.fixed_on <= target_date) or (
-            self.dismissed_on is not None and self.dismissed_on <= target_date
+        return (
+            (self.fixed_on is not None and self.fixed_on <= target_date)
+            or (self.dismissed_on is not None and self.dismissed_on <= target_date)
+            or (
+                self.auto_dismissed_on is not None
+                and self.auto_dismissed_on <= target_date
+            )
         )
 
     @staticmethod
@@ -25,6 +31,7 @@ class Vulnerability:
             dates.date_from_iso(my_dict["createdAt"]),
             dates.date_from_iso(my_dict["fixedAt"]),
             dates.date_from_iso(my_dict["dismissedAt"]),
+            dates.date_from_iso(my_dict["autoDismissedAt"]),
         )
 
 

--- a/tests/metrics/github/test_security.py
+++ b/tests/metrics/github/test_security.py
@@ -5,50 +5,58 @@ from metrics.github.github import Repo
 
 
 def test_vulnerability_open_on():
-    v = security.Vulnerability(datetime.date(2023, 10, 26), None, None)
+    v = security.Vulnerability(datetime.date(2023, 10, 26), None, None, None)
 
     assert v.is_open_on(datetime.date(2023, 10, 29))
 
 
 def test_vulnerability_open_on_same_day():
-    v = security.Vulnerability(datetime.date(2023, 10, 26), None, None)
+    v = security.Vulnerability(datetime.date(2023, 10, 26), None, None, None)
 
     assert v.is_open_on(datetime.date(2023, 10, 26))
 
 
 def test_vulnerability_open_on_date_in_past():
-    v = security.Vulnerability(datetime.date(2023, 10, 26), None, None)
+    v = security.Vulnerability(datetime.date(2023, 10, 26), None, None, None)
 
     assert not v.is_open_on(datetime.date(2023, 10, 20))
 
 
 def test_vulnerability_open_has_been_closed():
     v = security.Vulnerability(
-        datetime.date(2023, 10, 26), datetime.date(2023, 10, 28), None
+        datetime.date(2023, 10, 26), datetime.date(2023, 10, 28), None, None
     )
 
     assert not v.is_open_on(datetime.date(2023, 10, 30))
 
 
-def test_vulnerability_closed_on():
+def test_vulnerability_fixed_on_is_closed():
     v = security.Vulnerability(
-        datetime.date(2023, 10, 26), datetime.date(2023, 10, 28), None
+        datetime.date(2023, 10, 26), datetime.date(2023, 10, 28), None, None
     )
 
     assert v.is_closed_on(datetime.date(2023, 10, 29))
 
 
-def test_vulnerability_closed_on_still_open():
+def test_vulnerability_fixed_on_still_open():
     v = security.Vulnerability(
-        datetime.date(2023, 10, 26), datetime.date(2023, 10, 28), None
+        datetime.date(2023, 10, 26), datetime.date(2023, 10, 28), None, None
     )
 
     assert not v.is_closed_on(datetime.date(2023, 10, 27))
 
 
-def test_vulnerability_closed_on_is_closed():
+def test_vulnerability_dismissed_on_is_closed():
     v = security.Vulnerability(
-        datetime.date(2023, 10, 26), datetime.date(2023, 10, 28), None
+        datetime.date(2023, 10, 26), None, datetime.date(2023, 10, 28), None
+    )
+
+    assert v.is_closed_on(datetime.date(2023, 10, 29))
+
+
+def test_vulnerability_auto_dismssed_on_is_closed():
+    v = security.Vulnerability(
+        datetime.date(2023, 10, 26), None, None, datetime.date(2023, 10, 28)
     )
 
     assert v.is_closed_on(datetime.date(2023, 10, 29))
@@ -73,14 +81,32 @@ def test_vulnerabilities(monkeypatch):
                 createdAt="2023-10-13T00:00:00Z",
                 fixedAt="2023-10-20T00:00:00Z",
                 dismissedAt=None,
+                autoDismissedAt=None,
             ),
             dict(
                 createdAt="2023-10-13T00:00:00Z",
                 fixedAt=None,
                 dismissedAt="2023-10-21T00:00:00Z",
+                autoDismissedAt=None,
             ),
-            dict(createdAt="2023-10-26T00:00:00Z", fixedAt=None, dismissedAt=None),
-            dict(createdAt="2023-10-29T00:00:00Z", fixedAt=None, dismissedAt=None),
+            dict(
+                createdAt="2023-10-13T00:00:00Z",
+                fixedAt=None,
+                dismissedAt=None,
+                autoDismissedAt="2023-10-22T00:00:00Z",
+            ),
+            dict(
+                createdAt="2023-10-26T00:00:00Z",
+                fixedAt=None,
+                dismissedAt=None,
+                autoDismissedAt=None,
+            ),
+            dict(
+                createdAt="2023-10-29T00:00:00Z",
+                fixedAt=None,
+                dismissedAt=None,
+                autoDismissedAt=None,
+            ),
         ]
 
     monkeypatch.setattr(security.query, "vulnerabilities", fake_vulnerabilities)
@@ -92,7 +118,7 @@ def test_vulnerabilities(monkeypatch):
         "time": datetime.date(2023, 10, 13),
         "value": 0,
         "closed": 0,
-        "open": 2,
+        "open": 3,
         "organisation": "test-org",
         "repo": "test",
         "has_alerts_enabled": True,
@@ -101,7 +127,7 @@ def test_vulnerabilities(monkeypatch):
         "time": datetime.date(2023, 10, 20),
         "value": 0,
         "closed": 1,
-        "open": 1,
+        "open": 2,
         "organisation": "test-org",
         "repo": "test",
         "has_alerts_enabled": True,
@@ -109,7 +135,7 @@ def test_vulnerabilities(monkeypatch):
     assert result[33] == {
         "time": datetime.date(2023, 10, 29),
         "value": 0,
-        "closed": 2,
+        "closed": 3,
         "open": 2,
         "organisation": "test-org",
         "repo": "test2",


### PR DESCRIPTION
The way we've dismissed the vulnerabilities in python-docker has set them to "auto-dismissed" status rather than "dismissed". Previously we were reading that status as still open.

Tested locally to check that we see the expected drop in reported vulnerabilities.

![image](https://github.com/user-attachments/assets/05b83651-d4fa-408b-be1b-06a8682711af)
