### PR TITLE
Document additional Grafana storage configuration

### DIFF
--- a/grafana/README.md
+++ b/grafana/README.md
@@ -21,6 +21,13 @@ dokku$ dokku docker-options:add grafana deploy "--user 1013"
 dokku$ dokku docker-options:add grafana run "--user 1013"
 dokku$ dokku storage:ensure-directory grafana
 
+# add a unified storage index path _per container_
+# this allows blue/green deployments without encountering lock errors on this index
+# "Please note that sharing the same index_path between multiple running Grafana instances is not supported."
+# reference: https://github.com/grafana/grafana/blob/e845cd74ee32e71f62aa7f3824e118bdc50feff0/conf/defaults.ini#L2449-L2454
+myuser$ dokku docker-options:add grafana deploy "--tmpfs /var/lib/grafana/unified-search:uid=1013"
+myuser$ dokku docker-options:add grafana run "--tmpfs /var/lib/grafana/unified-search:uid=1013"
+
 myuser$ sudo chown -R dokku:dokku /var/lib/dokku/data/storage/grafana
 
 dokku$ dokku storage:mount grafana /var/lib/dokku/data/storage/grafana:/var/lib/grafana


### PR DESCRIPTION
# The problem

Not sure if this has happened before, but on a deployment of a Grafana image upgrade, we were seeing errors like:

```
Error: ✗ index is locked by another process: indexDir=/var/lib/grafana/unified-search/bleve/default/dashboards.dashboard.grafana.app/20260521-032608, err=timeout
```

This caused the deploy to fail, but the existing container to keep running, and the site available.

It was not even possible to do `dokku ps:restart` as the image could not be found:

```
$ dokku ps:restart grafana
 !     App image (dokku/grafana:latest) not found
 !     exit status 1
```

# Fixing the missing image

Fixing the "app image not found" required:

1. Finding the existing Grafana image in use by Docker
   * via `docker ps --filter "name=grafana.web" --format "table {{.ID}}\t{{.Names}}\t{{.Image}}"`
1. Retagging that as `dokku/grafana:latest`
   * via `docker tag "$IMAGE_ID" dokku/grafana:latest`

`dokku ps:restart grafana` still failed, but now with the same lock problem seen in the failed deployment. However, that was now for the same image that was already running in production.

# Using a `tmpfs` for the index

LLMs pointed me to Grafana's configuration settings and that showed a comment suggesting reusing the index between multiple instances was not supported.

This is a fairly recent Grafana change from 2026-01:

https://github.com/grafana/grafana/commit/1c5caeb987e056c77ec6455214d6a1ee4a9487eb

We do reuse data between multiple instances in Dokku. We run it with [zero downtime checks](https://dokku.com/docs/deployment/zero-downtime-deploys/), where a new container runs side-by-side with the existing one, until healthchecks pass.

Adding the tmpfs for Docker for this path and then redeploying fixed the lock, and Grafana upgraded:

```
dokku docker-options:add grafana run "--tmpfs /var/lib/grafana/unified-search:uid=1013"
dokku docker-options:add grafana run "--tmpfs /var/lib/grafana/unified-search:uid=1013"
```

(There was an incidental step where I did the same without the user ID, and encountered a file write permission error. I then removed those options and added the ones above.)

It should be safe since this is only an index, except that the index will need rebuilding on new deploys.