### PR TITLE
Remove `pip` configuration from `dependabot.yml`

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -30,15 +30,3 @@ updates:
       timezone: "Europe/London"
     cooldown:
       default-days: 7
-
-  - package-ecosystem: "pip"
-    directory: "/"
-    schedule:
-      interval: "weekly"
-      day: "monday"
-      time: "08:00"
-      timezone: "Europe/London"
-    # Setting this to 0 means that we get dependabot PRs for security updates only
-    open-pull-requests-limit: 0
-    cooldown:
-      default-days: 7


### PR DESCRIPTION
This isn't needed as we're using the `update-dependencies` action.