### PR TITLE
Fix cron monitor construction

### DIFF
--- a/metrics/sentry/cron.py
+++ b/metrics/sentry/cron.py
@@ -31,7 +31,7 @@ class Cron:
 
     def get_monitor(self, modname):
         monitor_slug = f"metrics-{modname}"
-        return self.Monitor(monitor_slug, _MONITOR_CONFIG)
+        return Monitor(monitor_slug, _MONITOR_CONFIG)
 
 
 class Monitor:


### PR DESCRIPTION
Fixes cron tasks failing before execution due to an invalid `Monitor` class reference.

`Monitor` was moved from a nested class to a module-level class, but `Cron.get_monitor()` continued calling `self.Monitor(...)` [in this commit](https://github.com/ebmdatalab/metrics/commit/bcaf000d51ad5b8ec82a4e2ff5632e04593d2572#diff-8eff5af6dac760e4e46bbc788b75a3313cf4943081ddcea453bab6ed7a39431fL22-R34).